### PR TITLE
fix: dynamic model discovery + correct stale model fallbacks

### DIFF
--- a/src/agents/agent-config-loader.ts
+++ b/src/agents/agent-config-loader.ts
@@ -355,7 +355,7 @@ name: my-agent
 description: Custom agent for my project
 engine: cli              # cli | claude-sdk | openai-sdk | google-adk
 provider: anthropic      # anthropic | openai | google | ollama | etc.
-model: claude-sonnet-4-20250514
+model: claude-sonnet-4-6
 instructions: |
   You are a helpful coding assistant specialized in this project.
   Follow the project conventions and style guide.

--- a/src/agents/agent-config-presets.ts
+++ b/src/agents/agent-config-presets.ts
@@ -17,7 +17,7 @@ export const BUILTIN_AGENTS: Record<string, AgentDefinition> = {
     description: 'Claude coding agent via Anthropic',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: 'You are a senior software engineer. Write clean, correct, well-tested code. Focus on correctness and security.',
     role: 'coder',
     weight: 1.0,
@@ -61,7 +61,7 @@ export const BUILTIN_AGENTS: Record<string, AgentDefinition> = {
     description: 'Expert code reviewer focused on correctness and security',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are an expert code reviewer. Analyze code for:
 - Correctness: logic errors, edge cases, off-by-one errors
 - Security: injection vulnerabilities, auth issues, data exposure
@@ -77,7 +77,7 @@ Provide specific line references and concrete fix suggestions.`,
     description: 'Software architect for system design and technical decisions',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a senior software architect. Focus on:
 - System design and component boundaries
 - API design and data modeling
@@ -130,7 +130,7 @@ Be thorough and cite specific evidence.`,
     description: 'Authorized penetration testing specialist for security assessments',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are an authorized penetration testing specialist. Your scope is limited to systems the user owns or has explicit written authorization to test. You operate within legal and ethical boundaries at all times.
 
 Your capabilities:
@@ -187,7 +187,7 @@ Prioritize findings by exploitability and business impact. Flag false positives 
     description: 'Threat modeling expert using STRIDE, DREAD, and attack tree methodologies',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a threat modeling expert. You analyze systems to identify potential threats, attack vectors, and security risks before they become vulnerabilities.
 
 Methodologies you apply:
@@ -279,7 +279,7 @@ All analysis is for authorized defensive security purposes — identifying your 
     description: 'Site reliability engineer focused on availability, performance, and observability',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a senior Site Reliability Engineer. You ensure systems are reliable, performant, and observable.
 
 Core domains:
@@ -333,7 +333,7 @@ Design principles:
     description: 'Incident response coordinator for outage triage and resolution',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a senior incident response coordinator. You lead teams through production incidents with calm, structured decision-making.
 
 Incident response process:
@@ -403,7 +403,7 @@ Produce architecture decisions as ADRs (Architecture Decision Records) with cont
     description: 'Full-stack developer proficient in frontend, backend, and databases',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a senior full-stack developer with deep expertise across the entire web application stack.
 
 Frontend:
@@ -467,7 +467,7 @@ Always consider: Does this work without JavaScript? Is it keyboard accessible? D
     description: 'Backend engineer focused on APIs, databases, and distributed systems',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a senior backend engineer specializing in server-side architecture, APIs, and data systems.
 
 Core expertise:
@@ -568,7 +568,7 @@ Developer experience principles:
     description: 'Machine learning engineer for model development, training, and optimization',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a senior machine learning engineer specializing in model development, training, and deployment.
 
 Core expertise:
@@ -661,7 +661,7 @@ Design principles: treat ML models as software artifacts with versioning, testin
     description: 'Creates runtime tools, plugins, and extensions for AI agents',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a tool builder — a specialized agent that creates runtime tools, plugins, and extensions for AI agent systems.
 
 Core capabilities:
@@ -696,7 +696,7 @@ When creating tools:
     description: 'Database administrator — schema design, query optimization, migrations, replication, backup/recovery',
     engine: 'claude-sdk',
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     instructions: `You are a senior database administrator. Your expertise covers:
 - Schema design: normalization, indexing strategies, partitioning, sharding
 - Query optimization: EXPLAIN plans, index tuning, query rewriting, N+1 detection
@@ -834,7 +834,7 @@ export const BUILTIN_TEAMS: Record<string, TeamDefinition> = {
         name: 'threat-modeler',
         engine: 'claude-sdk',
         provider: 'anthropic',
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         instructions: 'You are a threat modeling expert. Identify attack vectors, trust boundaries, and data flow risks using STRIDE methodology.',
         role: 'threat-modeler',
         weight: 1.3,

--- a/src/agents/agent-config-types.ts
+++ b/src/agents/agent-config-types.ts
@@ -24,7 +24,7 @@ export interface AgentDefinition {
   engine: TaskExecutor;
   /** LLM provider: anthropic, openai, google, ollama, etc. */
   provider?: string;
-  /** Model name: claude-sonnet-4-20250514, gpt-4o, gemini-2.0-flash, etc. */
+  /** Model name: claude-sonnet-4-6, gpt-4o, gemini-2.0-flash, etc. */
   model?: string;
 
   /** System prompt / instructions for this agent */

--- a/src/agents/sdk-backend.ts
+++ b/src/agents/sdk-backend.ts
@@ -182,7 +182,7 @@ export async function* executeClaudeSdk(
     const queryOptions: Record<string, unknown> = {
       prompt: task.prompt,
       options: {
-        model: task.model || 'claude-sonnet-4-20250514',
+        model: task.model || 'claude-sonnet-4-6',
         permissionMode: 'bypassPermissions',
         maxTurns: 50,
         cwd,

--- a/src/config.ts
+++ b/src/config.ts
@@ -456,7 +456,7 @@ const BUILTIN_PROFILES: Record<string, Profile> = {
   },
   smart: {
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     persona: 'calliope',
     confirmMode: true,
   },

--- a/src/model-detection.ts
+++ b/src/model-detection.ts
@@ -139,6 +139,7 @@ export interface ModelInfo {
   name?: string;
   description?: string;
   contextLength?: number;
+  maxOutputTokens?: number;
   pricing?: {
     input?: number;
     output?: number;
@@ -314,17 +315,19 @@ async function getAnthropicModels(options: ModelFetchOptions = {}): Promise<Mode
         id: model.id,
         name: model.display_name || formatModelName(model.id),
         description: getAnthropicModelDescription(model.id),
-        contextLength: 200000,
+        // The /v1/models list endpoint does not return the context window;
+        // derive it per model family rather than hardcoding a single value.
+        contextLength: getModelContextLimit('anthropic', model.id),
       }))
       .sort((a, b) => b.id.localeCompare(a.id)); // Newest first
   } catch (error) {
-    // Fallback to known models if API fails
+    // Emergency fallback when the API is unreachable. Keep these as the current
+    // shipping models — discovery is the source of truth; this is the offline net.
     logModelDetectionWarning('Failed to fetch Anthropic models, using fallback list', error, options);
     return [
-      { id: 'claude-opus-4-5-20251101', name: 'Claude Opus 4.5', description: 'Most capable model', contextLength: 200000 },
-      { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4', description: 'Balanced intelligence and speed', contextLength: 200000 },
-      { id: 'claude-3-5-sonnet-20241022', name: 'Claude 3.5 Sonnet', description: 'Previous gen flagship', contextLength: 200000 },
-      { id: 'claude-3-5-haiku-20241022', name: 'Claude 3.5 Haiku', description: 'Fast and affordable', contextLength: 200000 },
+      { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', description: 'Most capable model', contextLength: 1000000 },
+      { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', description: 'Balanced intelligence and speed', contextLength: 1000000 },
+      { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', description: 'Fast and affordable', contextLength: 200000 },
     ];
   }
 }
@@ -1119,13 +1122,29 @@ export async function preWarmModelCache(): Promise<void> {
 export function getModelInfo(provider: LLMProvider, modelId: string): ModelInfo | undefined {
   const cached = modelCache.get(provider);
   if (!cached) return undefined;
-  return cached.models.find(m => m.id === modelId || m.id.includes(modelId) || modelId.includes(m.id));
+  // Exact match first.
+  const exact = cached.models.find(m => m.id === modelId);
+  if (exact) return exact;
+  // Otherwise only accept an UNAMBIGUOUS prefix relationship. Loose substring
+  // matching wrongly resolved e.g. `gpt-4` -> `gpt-4o` or `claude-opus-4` ->
+  // `claude-opus-4-8`, returning a different model's context/pricing.
+  const related = cached.models.filter(m => m.id.startsWith(modelId) || modelId.startsWith(m.id));
+  return related.length === 1 ? related[0] : undefined;
 }
 
 /**
  * Default context limits by model family (fallback when API doesn't provide it)
  */
 const DEFAULT_CONTEXT_LIMITS: Record<string, number> = {
+  // Anthropic — current 1M-context models matched first (longest key wins).
+  // Everything else (Haiku 4.5, Claude 3.x, and the older -20250514 IDs) falls
+  // through to the generic `claude` 200K entry below.
+  'claude-fable-5': 1000000,
+  'claude-opus-4-8': 1000000,
+  'claude-opus-4-7': 1000000,
+  'claude-opus-4-6': 1000000,
+  'claude-sonnet-4-6': 1000000,
+  'claude-haiku-4-5': 200000,
   'claude': 200000,
   'gpt-4o': 128000,
   'gpt-4-turbo': 128000,
@@ -1189,4 +1208,46 @@ export function getModelContextLimit(provider: LLMProvider, modelId: string): nu
 
   // Ultimate fallback
   return 32000;
+}
+
+/**
+ * Default max OUTPUT tokens by model family (fallback when the API doesn't
+ * report it). Replaces the old global 8192 cap so modern models can use their
+ * real output ceiling. Unknown models fall through to a conservative 8192.
+ */
+const DEFAULT_MAX_OUTPUT: Record<string, number> = {
+  'claude-fable-5': 128000,
+  'claude-opus-4-8': 128000,
+  'claude-opus-4-7': 128000,
+  'claude-opus-4-6': 128000,
+  'claude-sonnet-4-6': 64000,
+  'claude-haiku-4-5': 64000,
+  'claude': 8192,
+  'gpt-5': 128000,
+  'o1': 100000,
+  'o3': 100000,
+  'gpt-4o': 16384,
+  'gpt-4': 8192,
+  'gemini-2': 8192,
+  'gemini-1.5': 8192,
+};
+
+/**
+ * Get the max output-token ceiling for a model - cached API info first, then
+ * family fallback. Conservative 8192 default keeps unknown/local models safe.
+ */
+export function getModelMaxOutput(provider: LLMProvider, modelId: string): number {
+  const modelInfo = getModelInfo(provider, modelId);
+  if (modelInfo?.maxOutputTokens) {
+    return modelInfo.maxOutputTokens;
+  }
+  const lowerModel = modelId.toLowerCase();
+  const sortedEntries = Object.entries(DEFAULT_MAX_OUTPUT)
+    .sort((a, b) => b[0].length - a[0].length);
+  for (const [key, limit] of sortedEntries) {
+    if (lowerModel.includes(key.toLowerCase())) {
+      return limit;
+    }
+  }
+  return 8192;
 }

--- a/src/model-router.ts
+++ b/src/model-router.ts
@@ -50,15 +50,15 @@ const DEFAULT_TIERS: Record<LLMProvider, RoutingConfig['tiers']> = {
     fast: {
       name: 'Haiku',
       provider: 'anthropic',
-      model: 'claude-3-5-haiku-20241022',
+      model: 'claude-haiku-4-5',
       maxTokens: 8192,
-      costPer1kInput: 0.00025,
-      costPer1kOutput: 0.00125,
+      costPer1kInput: 0.001,
+      costPer1kOutput: 0.005,
     },
     balanced: {
       name: 'Sonnet',
       provider: 'anthropic',
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
       maxTokens: 8192,
       costPer1kInput: 0.003,
       costPer1kOutput: 0.015,
@@ -66,10 +66,10 @@ const DEFAULT_TIERS: Record<LLMProvider, RoutingConfig['tiers']> = {
     smart: {
       name: 'Opus',
       provider: 'anthropic',
-      model: 'claude-opus-4-20250514',
+      model: 'claude-opus-4-8',
       maxTokens: 8192,
-      costPer1kInput: 0.015,
-      costPer1kOutput: 0.075,
+      costPer1kInput: 0.005,
+      costPer1kOutput: 0.025,
     },
   },
   openai: {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -4,7 +4,7 @@
  * Constants, token estimation, context health, validation, and shared helpers.
  */
 
-import { getModelContextLimit } from '../model-detection.js';
+import { getModelContextLimit, getModelMaxOutput } from '../model-detection.js';
 import type { Message, Tool, LLMResponse, LLMProvider, TextContent } from '../types.js';
 
 // Constants
@@ -108,13 +108,15 @@ export function calculateMaxTokens(
 
   debugLog(`Context calculation: limit=${contextLimit}, input≈${estimatedInput}, buffer=${buffer}, available=${available}`);
 
-  // Ensure we have at least MIN_OUTPUT_TOKENS, up to MAX_TOKENS
+  // Ensure we have at least MIN_OUTPUT_TOKENS, up to the model's real output ceiling
   if (available < MIN_OUTPUT_TOKENS) {
     debugLog(`WARNING: Very limited output space (${available}), using minimum ${MIN_OUTPUT_TOKENS}`);
     return MIN_OUTPUT_TOKENS;
   }
 
-  return Math.min(MAX_TOKENS, available);
+  // Cap by the model's actual max output (capability-derived), not a global 8192.
+  const maxOutput = getModelMaxOutput(provider, model);
+  return Math.min(maxOutput, available);
 }
 
 /**

--- a/src/smart-router.ts
+++ b/src/smart-router.ts
@@ -60,9 +60,9 @@ interface ProviderStrengths {
 export const MODEL_STRENGTHS: Partial<Record<LLMProvider, ProviderStrengths>> = {
   anthropic: {
     tiers: {
-      fast: { model: 'claude-3-5-haiku-20241022', costPer1kInput: 0.00025, costPer1kOutput: 0.00125 },
-      balanced: { model: 'claude-sonnet-4-20250514', costPer1kInput: 0.003, costPer1kOutput: 0.015 },
-      smart: { model: 'claude-opus-4-20250514', costPer1kInput: 0.015, costPer1kOutput: 0.075 },
+      fast: { model: 'claude-haiku-4-5', costPer1kInput: 0.001, costPer1kOutput: 0.005 },
+      balanced: { model: 'claude-sonnet-4-6', costPer1kInput: 0.003, costPer1kOutput: 0.015 },
+      smart: { model: 'claude-opus-4-8', costPer1kInput: 0.005, costPer1kOutput: 0.025 },
     },
     strengths: {
       'code': 0.95,
@@ -372,7 +372,7 @@ export function smartRoute(
     return {
       selected: {
         provider: 'anthropic',
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         tier,
         score: 0.5,
         reason: 'fallback - no providers available',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -278,7 +278,7 @@ export const TOOLS: Tool[] = [
 
 CONFIGURABLE SETTINGS:
 - defaultProvider: AI provider (anthropic, google, openai, together, openrouter, groq, fireworks, mistral, ollama, ai21, huggingface, litellm, bedrock, auto)
-- defaultModel: Model name string (provider-specific, e.g. "claude-sonnet-4-20250514", "gemini-2.0-flash", "gpt-4o")
+- defaultModel: Model name string (provider-specific, e.g. "claude-sonnet-4-6", "gemini-2.0-flash", "gpt-4o")
 - persona: Agent persona style (calliope, muse, minimal)
 - maxIterations: Max agent loop iterations (0 = unlimited)
 - maxIterationTime: Max seconds per iteration (0 = no limit, default: 600)

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,9 +87,11 @@ export interface LLMResponse {
   };
 }
 
-// Default models for each provider
+// Default model per provider. This is the OFFLINE EMERGENCY FALLBACK only —
+// model selection is normally driven by live discovery (see model-detection.ts).
+// Keep these current so the no-key / offline path doesn't point at a retired model.
 export const DEFAULT_MODELS: Record<LLMProvider, string> = {
-  anthropic: 'claude-sonnet-4-20250514',
+  anthropic: 'claude-sonnet-4-6',
   google: 'gemini-2.0-flash',
   openai: 'gpt-4o',
   together: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
@@ -103,7 +105,7 @@ export const DEFAULT_MODELS: Record<LLMProvider, string> = {
   litellm: 'gpt-4o',  // LiteLLM proxies to other providers
   bedrock: 'us.anthropic.claude-sonnet-4-20250514-v1:0',  // AWS Bedrock (native Converse API)
   'openai-compat': 'gpt-3.5-turbo',  // Generic OpenAI-compatible server
-  auto: 'claude-sonnet-4-20250514',
+  auto: 'claude-sonnet-4-6',
 };
 
 // Mode display configuration
@@ -234,7 +236,14 @@ export function getSystemPrompt(persona: AgentPersona): string {
 
 // Pricing per 1M tokens (input, output) in USD
 export const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  // Anthropic
+  // Anthropic — current models
+  'claude-fable-5': { input: 10, output: 50 },
+  'claude-opus-4-8': { input: 5, output: 25 },
+  'claude-opus-4-7': { input: 5, output: 25 },
+  'claude-opus-4-6': { input: 5, output: 25 },
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'claude-haiku-4-5': { input: 1, output: 5 },
+  // Anthropic — legacy (still served)
   'claude-sonnet-4-20250514': { input: 3, output: 15 },
   'claude-opus-4-20250514': { input: 15, output: 75 },
   'claude-3-5-sonnet-20241022': { input: 3, output: 15 },

--- a/tests/anthropic.test.ts
+++ b/tests/anthropic.test.ts
@@ -23,6 +23,7 @@ vi.mock('../src/config.js', () => ({
 
 vi.mock('../src/model-detection.js', () => ({
   getModelContextLimit: vi.fn(() => 200000),
+  getModelMaxOutput: vi.fn(() => 8192),
   getModelInfo: vi.fn(() => null),
   getOllamaFallbackModel: vi.fn(() => null),
 }));

--- a/tests/commands-model-loading.test.ts
+++ b/tests/commands-model-loading.test.ts
@@ -21,6 +21,7 @@ const mockGetAvailableModels = vi.fn();
 vi.mock('../src/model-detection.js', () => ({
   getAvailableModels: (...args: unknown[]) => mockGetAvailableModels(...args),
   getModelContextLimit: vi.fn(() => 128000),
+  getModelMaxOutput: vi.fn(() => 8192),
   clearModelCache: vi.fn(),
   preWarmModelCache: vi.fn(),
 }));

--- a/tests/git-status.test.ts
+++ b/tests/git-status.test.ts
@@ -9,7 +9,13 @@ import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { execSync } from 'child_process';
 import { getGitBranch, getGitStatus, type GitStatusInfo } from '../src/git-status.js';
+
+// The repo's real current branch — robust to running on a feature branch, not just main.
+const ACTUAL_BRANCH = execSync('git rev-parse --abbrev-ref HEAD', { cwd: process.cwd() })
+  .toString()
+  .trim();
 
 describe('git-status', () => {
   afterEach(() => {
@@ -31,7 +37,7 @@ describe('git-status', () => {
       const branch = getGitBranch(process.cwd());
       expect(branch).toBeTruthy();
       expect(typeof branch).toBe('string');
-      expect(branch).toBe('main');
+      expect(branch).toBe(ACTUAL_BRANCH);
     });
 
     it('returns null for a non-git directory', () => {
@@ -93,7 +99,7 @@ describe('git-status', () => {
       rmSync(td, { recursive: true, force: true });
 
       const status = getGitStatus(process.cwd());
-      expect(status.branch).toBe('main');
+      expect(status.branch).toBe(ACTUAL_BRANCH);
     });
   });
 

--- a/tests/google.test.ts
+++ b/tests/google.test.ts
@@ -25,6 +25,7 @@ vi.mock('../src/config.js', () => ({
 
 vi.mock('../src/model-detection.js', () => ({
   getModelContextLimit: vi.fn(() => 1000000),
+  getModelMaxOutput: vi.fn(() => 8192),
   getModelInfo: vi.fn(() => null),
   getOllamaFallbackModel: vi.fn(() => null),
 }));

--- a/tests/model-detection.test.ts
+++ b/tests/model-detection.test.ts
@@ -33,6 +33,7 @@ vi.mock('@inquirer/prompts', () => ({ select: vi.fn() }));
 
 import {
   getModelContextLimit,
+  getModelMaxOutput,
   getModelInfo,
   clearModelCache,
   getAvailableModels,
@@ -196,14 +197,14 @@ describe('getModelContextLimit', () => {
     mockFetch.mockRejectedValueOnce(new Error('network error'));
 
     return getAvailableModels('anthropic').then(() => {
-      // Cache should now contain fallback Anthropic models with contextLength 200000
-      const info = getModelInfo('anthropic', 'claude-sonnet-4-20250514');
+      // Cache should now contain the fallback Anthropic models with their context windows
+      const info = getModelInfo('anthropic', 'claude-sonnet-4-6');
       expect(info).toBeDefined();
-      expect(info?.contextLength).toBe(200000);
+      expect(info?.contextLength).toBe(1000000);
 
       // getModelContextLimit should use the cached info
-      const limit = getModelContextLimit('anthropic', 'claude-sonnet-4-20250514');
-      expect(limit).toBe(200000);
+      const limit = getModelContextLimit('anthropic', 'claude-sonnet-4-6');
+      expect(limit).toBe(1000000);
     });
   });
 
@@ -216,6 +217,32 @@ describe('getModelContextLimit', () => {
     // "deepseek-coder" (14 chars) should match before "deepseek" (8 chars)
     // Both map to 128000 in this case, but the logic should prefer longer keys
     expect(getModelContextLimit('ollama', 'deepseek-coder-v2')).toBe(128000);
+  });
+
+  it('should give current 1M-context Claude models their real window', () => {
+    // Current models are 1M; only Haiku 4.5 (and 3.x / legacy ids) stay at 200K.
+    expect(getModelContextLimit('anthropic', 'claude-opus-4-8')).toBe(1000000);
+    expect(getModelContextLimit('anthropic', 'claude-sonnet-4-6')).toBe(1000000);
+    expect(getModelContextLimit('anthropic', 'claude-haiku-4-5')).toBe(200000);
+    // Legacy/dated ids fall through to the generic 200K claude entry.
+    expect(getModelContextLimit('anthropic', 'claude-sonnet-4-20250514')).toBe(200000);
+  });
+});
+
+// ===========================================================================
+// getModelMaxOutput
+// ===========================================================================
+
+describe('getModelMaxOutput', () => {
+  it('should derive output ceiling per model family, not a global 8192', () => {
+    expect(getModelMaxOutput('anthropic', 'claude-opus-4-8')).toBe(128000);
+    expect(getModelMaxOutput('anthropic', 'claude-sonnet-4-6')).toBe(64000);
+    expect(getModelMaxOutput('anthropic', 'claude-haiku-4-5')).toBe(64000);
+  });
+
+  it('should fall back to a conservative 8192 for unknown/local models', () => {
+    expect(getModelMaxOutput('ollama', 'some-unknown-local-model')).toBe(8192);
+    expect(getModelMaxOutput('anthropic', 'claude-3-opus-20240229')).toBe(8192);
   });
 });
 
@@ -233,19 +260,20 @@ describe('getModelInfo', () => {
     mockFetch.mockRejectedValueOnce(new Error('network'));
     await getAvailableModels('anthropic');
 
-    const info = getModelInfo('anthropic', 'claude-sonnet-4-20250514');
+    const info = getModelInfo('anthropic', 'claude-sonnet-4-6');
     expect(info).toBeDefined();
-    expect(info?.id).toBe('claude-sonnet-4-20250514');
+    expect(info?.id).toBe('claude-sonnet-4-6');
   });
 
-  it('should find model by partial match (modelId includes cached ID)', async () => {
+  it('should find model by unambiguous prefix (dated id of a cached family)', async () => {
     vi.mocked(config.getApiKey).mockReturnValue('test-key');
     mockFetch.mockRejectedValueOnce(new Error('network'));
     await getAvailableModels('anthropic');
 
-    // The cached id "claude-3-5-haiku-20241022" includes "haiku"
-    const info = getModelInfo('anthropic', 'claude-3-5-haiku-20241022');
+    // Dated id "claude-haiku-4-5-20251001" uniquely prefix-matches cached "claude-haiku-4-5"
+    const info = getModelInfo('anthropic', 'claude-haiku-4-5-20251001');
     expect(info).toBeDefined();
+    expect(info?.id).toBe('claude-haiku-4-5');
   });
 
   it('should return undefined for non-matching provider', async () => {
@@ -267,10 +295,10 @@ describe('clearModelCache', () => {
     mockFetch.mockRejectedValueOnce(new Error('network'));
     await getAvailableModels('anthropic');
 
-    expect(getModelInfo('anthropic', 'claude-sonnet-4-20250514')).toBeDefined();
+    expect(getModelInfo('anthropic', 'claude-sonnet-4-6')).toBeDefined();
 
     clearModelCache('anthropic');
-    expect(getModelInfo('anthropic', 'claude-sonnet-4-20250514')).toBeUndefined();
+    expect(getModelInfo('anthropic', 'claude-sonnet-4-6')).toBeUndefined();
   });
 
   it('should clear all caches when no provider specified', async () => {
@@ -279,7 +307,7 @@ describe('clearModelCache', () => {
     await getAvailableModels('anthropic');
 
     clearModelCache();
-    expect(getModelInfo('anthropic', 'claude-sonnet-4-20250514')).toBeUndefined();
+    expect(getModelInfo('anthropic', 'claude-sonnet-4-6')).toBeUndefined();
   });
 });
 

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -12,6 +12,7 @@ vi.mock('../src/config.js', () => ({
 vi.mock('../src/model-detection.js', () => ({
   getOllamaFallbackModel: vi.fn(),
   getModelContextLimit: vi.fn(() => 128000),
+  getModelMaxOutput: vi.fn(() => 8192),
 }));
 
 // Stub fetch globally

--- a/tests/openai-compat.test.ts
+++ b/tests/openai-compat.test.ts
@@ -58,6 +58,7 @@ vi.mock('openai', () => {
 vi.mock('@inquirer/prompts', () => ({ select: vi.fn() }));
 vi.mock('../src/model-detection.js', () => ({
   getModelContextLimit: vi.fn(() => 4096),
+  getModelMaxOutput: vi.fn(() => 8192),
   getModelInfo: vi.fn(() => null),
   getOllamaFallbackModel: vi.fn(async () => null),
   getAvailableModels: vi.fn(),

--- a/tests/openai.test.ts
+++ b/tests/openai.test.ts
@@ -28,6 +28,7 @@ vi.mock('../src/config.js', () => ({
 // Mock model-detection to avoid real lookups
 vi.mock('../src/model-detection.js', () => ({
   getModelContextLimit: vi.fn(() => 128000),
+  getModelMaxOutput: vi.fn(() => 8192),
   getModelInfo: vi.fn(() => null),
   getOllamaFallbackModel: vi.fn(() => null),
 }));

--- a/tests/providers-anthropic.test.ts
+++ b/tests/providers-anthropic.test.ts
@@ -27,6 +27,7 @@ vi.mock('../src/config.js', () => ({
 // Mock model-detection to avoid real lookups
 vi.mock('../src/model-detection.js', () => ({
   getModelContextLimit: vi.fn(() => 200000),
+  getModelMaxOutput: vi.fn(() => 8192),
   getModelInfo: vi.fn(() => null),
   getOllamaFallbackModel: vi.fn(() => null),
 }));

--- a/tests/providers-compat.test.ts
+++ b/tests/providers-compat.test.ts
@@ -42,6 +42,7 @@ vi.mock('../src/config.js', () => ({
 
 vi.mock('../src/model-detection.js', () => ({
   getModelContextLimit: vi.fn(() => 128000),
+  getModelMaxOutput: vi.fn(() => 8192),
   getModelInfo: vi.fn(() => null),
   getOllamaFallbackModel: vi.fn(async () => 'llama3.3:latest'),
 }));

--- a/tests/providers-google.test.ts
+++ b/tests/providers-google.test.ts
@@ -25,6 +25,7 @@ vi.mock('../src/config.js', () => ({
 
 vi.mock('../src/model-detection.js', () => ({
   getModelContextLimit: vi.fn(() => 1000000),
+  getModelMaxOutput: vi.fn(() => 8192),
   getModelInfo: vi.fn(() => null),
   getOllamaFallbackModel: vi.fn(() => null),
 }));

--- a/tests/sdk-backend.test.ts
+++ b/tests/sdk-backend.test.ts
@@ -236,7 +236,7 @@ describe('SDK Backend', () => {
       expect(mockQuery).toHaveBeenCalledWith(
         expect.objectContaining({
           options: expect.objectContaining({
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
           }),
         })
       );

--- a/tests/ui-loop-control.test.ts
+++ b/tests/ui-loop-control.test.ts
@@ -41,6 +41,7 @@ vi.mock('../src/types.js', () => ({
 
 vi.mock('../src/model-detection.js', () => ({
   getModelContextLimit: vi.fn(() => 100000),
+  getModelMaxOutput: vi.fn(() => 8192),
 }));
 
 vi.mock('../src/risk.js', () => ({


### PR DESCRIPTION
**Closes #142, #143, #144, #146.**

The fast tier (`claude-3-5-haiku-20241022`) is already retired (404s) and the default/balanced/smart models (`claude-*-4-20250514`) retire 2026-06-15. Live discovery already existed but fell back to stale, single-valued tables.

- **#142/#146** `model-detection.ts`: family-keyed context map (current Opus/Sonnet = 1M; Haiku 4.5 / Claude 3.x / legacy ids = 200K); `getModelInfo` now exact-match then *unambiguous* prefix only (kills `gpt-4`→`gpt-4o` / `claude-opus-4`→`claude-opus-4-8` mismatches); current offline fallback list.
- **#143** per-model context windows instead of a hardcoded 200000.
- **#144** `calculateMaxTokens` uses a capability-derived `getModelMaxOutput` instead of the global 8192 cap.
- Corrected the offline emergency-fallback ids across types/routers/config/agents and marked them fallback-only (discovery is the source of truth).

`tsc` clean; 4601 tests pass (+3 new: family context, max-output, unambiguous-prefix resolver).