### PR TITLE
fix(data): atomic persistence, session deletion, context-state correctness

### DIFF
--- a/src/auto-checkpoint.ts
+++ b/src/auto-checkpoint.ts
@@ -39,6 +39,8 @@ const DESTRUCTIVE_SHELL_PATTERNS = [
 
 let enabled = true;
 let lastCheckpointHash: string | null = null;
+/** Repo root the lastCheckpointHash belongs to — revert must target this, not live cwd. */
+let lastCheckpointRoot: string | null = null;
 let checkpointCount = 0;
 
 // ============================================================================
@@ -70,15 +72,20 @@ export function createCheckpoint(tool: string, args: Record<string, unknown>): s
   if (!isGitRepo()) return null;
 
   try {
+    // Capture the repo root once, at checkpoint time, and pin every git call for
+    // this checkpoint to it. process.cwd() may change before the matching revert.
+    const root = gitRepoRoot();
+    if (!root) return null;
+
     // Check if there are any changes to commit
-    const status = git('status', '--porcelain');
+    const status = git(root, 'status', '--porcelain');
     if (!status.trim()) return null; // Nothing to checkpoint
 
     // Stage all tracked changes (don't add untracked files)
-    git('add', '-u');
+    git(root, 'add', '-u');
 
     // Check if there's anything staged
-    const staged = git('diff', '--cached', '--stat');
+    const staged = git(root, 'diff', '--cached', '--stat');
     if (!staged.trim()) return null;
 
     // Create checkpoint commit
@@ -89,11 +96,12 @@ export function createCheckpoint(tool: string, args: Record<string, unknown>): s
         : tool;
 
     const message = `[auto-checkpoint] before ${tool}: ${argSummary}`;
-    git('commit', '-m', message, '--no-gpg-sign');
+    git(root, 'commit', '-m', message, '--no-gpg-sign');
 
     // Get the commit hash
-    const hash = git('rev-parse', '--short', 'HEAD').trim();
+    const hash = git(root, 'rev-parse', '--short', 'HEAD').trim();
     lastCheckpointHash = hash;
+    lastCheckpointRoot = root;
     checkpointCount++;
     return hash;
   } catch {
@@ -106,10 +114,21 @@ export function createCheckpoint(tool: string, args: Record<string, unknown>): s
  * Revert to the last checkpoint.
  */
 export function revertToLastCheckpoint(): boolean {
-  if (!lastCheckpointHash || !isGitRepo()) return false;
+  if (!lastCheckpointHash || !lastCheckpointRoot) return false;
+
+  // Reset only the repo the checkpoint was created in. If that root has since
+  // moved or no longer resolves to the same repo, bail rather than risk a
+  // destructive cross-repo `git reset --hard` against the live cwd.
+  let currentRoot: string | null;
+  try {
+    currentRoot = gitRepoRoot(lastCheckpointRoot);
+  } catch {
+    return false;
+  }
+  if (currentRoot !== lastCheckpointRoot) return false;
 
   try {
-    git('reset', '--hard', lastCheckpointHash);
+    git(lastCheckpointRoot, 'reset', '--hard', lastCheckpointHash);
     return true;
   } catch {
     return false;
@@ -134,22 +153,35 @@ export function setEnabled(value: boolean): void {
 // Helpers
 // ============================================================================
 
-let _isGitRepo: boolean | null = null;
-
-function isGitRepo(): boolean {
-  if (_isGitRepo !== null) return _isGitRepo;
+/**
+ * Whether the given directory (default: live cwd) is inside a git work tree.
+ * Not memoized: the answer depends on cwd, which changes over a session.
+ */
+function isGitRepo(cwd: string = process.cwd()): boolean {
   try {
-    git('rev-parse', '--is-inside-work-tree');
-    _isGitRepo = true;
+    git(cwd, 'rev-parse', '--is-inside-work-tree');
+    return true;
   } catch {
-    _isGitRepo = false;
+    return false;
   }
-  return _isGitRepo;
 }
 
-function git(...args: string[]): string {
+/**
+ * Resolve the absolute repo root for the given directory (default: live cwd).
+ * Returns null if not inside a git work tree.
+ */
+function gitRepoRoot(cwd: string = process.cwd()): string | null {
+  try {
+    const root = git(cwd, 'rev-parse', '--show-toplevel').trim();
+    return root || null;
+  } catch {
+    return null;
+  }
+}
+
+function git(cwd: string, ...args: string[]): string {
   return execFileSync('git', args, {
-    cwd: process.cwd(),
+    cwd,
     encoding: 'utf-8',
     timeout: 5000,
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/auto-compressor.ts
+++ b/src/auto-compressor.ts
@@ -6,7 +6,7 @@
  */
 
 import { chat } from './providers/index.js';
-import { summarizeMessages, estimateTotalTokens } from './summarization.js';
+import { summarizeMessages, estimateTotalTokens, validateMessageHistory } from './summarization.js';
 import type { Message as LLMMessage, LLMProvider, Tool } from './types.js';
 
 // ============================================================================
@@ -233,12 +233,15 @@ export async function autoCompress(
     method = 'heuristic';
   }
 
-  // Build compressed messages
-  const compressed: LLMMessage[] = [
+  // Build compressed messages. The positional slice can orphan a tool_use/result
+  // pair across the keep boundary (e.g. a kept `tool` result whose assistant
+  // `tool_use` was summarized away), which would 400 on the next provider call.
+  // validateMessageHistory strips any such orphaned tool blocks before returning.
+  const compressed: LLMMessage[] = validateMessageHistory([
     ...systemMessages,
     { role: 'system', content: `[Auto-compressed context — ${method} summary of ${toSummarize.length} messages]\n\n${summary}` },
     ...toKeep,
-  ];
+  ]);
 
   const compressedTokens = estimateTotalTokens(compressed);
   if (compressedTokens >= currentTokens) {

--- a/src/branching.ts
+++ b/src/branching.ts
@@ -87,7 +87,16 @@ export function loadBranchState(sessionId: string): BranchState {
  */
 export function saveBranchState(sessionId: string, state: BranchState): void {
   const stateFile = getStateFile(sessionId);
-  fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+  // Atomic write: a crash or concurrent instance must never leave a truncated
+  // branch-state file (readers fall back to defaults on parse error).
+  const tmp = `${stateFile}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+    fs.renameSync(tmp, stateFile);
+  } catch (e) {
+    try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    throw e;
+  }
 }
 
 // ============================================================================

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -115,7 +115,15 @@ export function createCheckpoint(filePath: string, content?: string, sessionId?:
   const filename = makeFilename(timestamp);
   const fullPath = path.join(dir, filename);
 
-  fs.writeFileSync(fullPath, JSON.stringify(checkpoint, null, 2));
+  // Atomic write so a crash mid-write can't leave a truncated checkpoint.
+  const tmp = `${fullPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(checkpoint, null, 2));
+    fs.renameSync(tmp, fullPath);
+  } catch (e) {
+    try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    throw e;
+  }
   return filename;
 }
 

--- a/src/idle-eviction.ts
+++ b/src/idle-eviction.ts
@@ -26,6 +26,8 @@ let lastActivityMs = Date.now();
 let checkInterval: ReturnType<typeof setInterval> | null = null;
 let callbacks: EvictionCallback[] = [];
 let evictionCount = 0;
+/** Latch so auto-save/evict fires once per idle period, not every check tick. */
+let hasEvicted = false;
 
 /** Configure eviction behavior */
 export function configureEviction(opts: Partial<EvictionConfig>): void {
@@ -45,6 +47,8 @@ export function onEviction(cb: EvictionCallback): void {
 /** Record user activity */
 export function recordActivity(): void {
   lastActivityMs = Date.now();
+  // Reset the latch so the next idle period can evict again.
+  hasEvicted = false;
 }
 
 /** Get idle duration in ms */
@@ -78,12 +82,15 @@ export function stopMonitor(): void {
 
 function checkIdle(): void {
   const idle = Date.now() - lastActivityMs;
-  if (idle >= config.idleThresholdMs) {
+  // Latch: fire callbacks once per idle period (when crossing the threshold),
+  // not on every check tick while still idle. recordActivity() clears the latch.
+  if (idle >= config.idleThresholdMs && !hasEvicted) {
     evictionCount++;
     if (config.autoSaveOnEvict) {
       for (const cb of callbacks) cb('auto-save');
     }
     for (const cb of callbacks) cb('evict');
+    hasEvicted = true;
   }
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -150,12 +150,31 @@ function readJSON<T>(filePath: string, defaultValue: T): T {
   return defaultValue;
 }
 
+/**
+ * Atomically write JSON to disk. Serializes to a uniquely-named temp file in the
+ * target's own directory, then renames it into place. rename(2) is atomic within
+ * a filesystem, so a concurrent reader sees either the old or the new file, never a
+ * truncated partial write. The unique temp name (pid + timestamp) prevents two
+ * concurrent instances from clobbering each other's temp file, and the temp file is
+ * cleaned up if the write/rename fails.
+ */
 function writeJSON(filePath: string, data: unknown): void {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+  const tmp = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(data, null, 2));
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // temp file may not exist; ignore cleanup failures
+    }
+    throw err;
+  }
 }
 
 // ============================================================================
@@ -224,11 +243,46 @@ function readChatHistory(filePath: string): ChatMessage[] {
   }
 }
 
+/**
+ * Retention/rotation policy for per-session chat.log.
+ *
+ * chat.log is rotated to chat.log.1 (overwriting any previous rotation) once it
+ * exceeds CHAT_LOG_MAX_BYTES, bounding on-disk growth to ~2x the cap per session.
+ * Override the default via the CALLIOPE_CHAT_LOG_MAX_BYTES env var (bytes).
+ */
+const DEFAULT_CHAT_LOG_MAX_BYTES = 5 * 1024 * 1024; // 5 MiB
+
+function getChatLogMaxBytes(): number {
+  const raw = process.env.CALLIOPE_CHAT_LOG_MAX_BYTES;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_CHAT_LOG_MAX_BYTES;
+}
+
+/**
+ * Rotate chat.log to chat.log.1 if it has grown past the configured cap.
+ * The previous chat.log.1 (if any) is overwritten, so retention is bounded to
+ * the two most recent log segments.
+ */
+function rotateChatLogIfNeeded(filePath: string): void {
+  try {
+    if (!fs.existsSync(filePath)) return;
+    const size = fs.statSync(filePath).size;
+    if (size < getChatLogMaxBytes()) return;
+    fs.renameSync(filePath, `${filePath}.1`);
+  } catch {
+    // Rotation is best-effort; never break the append path.
+  }
+}
+
 function appendChatMessage(filePath: string, msg: ChatMessage): void {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
+  rotateChatLogIfNeeded(filePath);
   fs.appendFileSync(filePath, formatChatMessage(msg) + '\n');
 }
 
@@ -431,8 +485,8 @@ export function deleteSession(sessionId: string): boolean {
   initStorage();
 
   try {
-    const sessionDir = path.join(paths.sessions, sessionId);
-    if (fs.existsSync(sessionDir)) {
+    const sessionDir = getSessionDirById(sessionId);
+    if (sessionDir && fs.existsSync(sessionDir)) {
       fs.rmSync(sessionDir, { recursive: true });
       return true;
     }
@@ -534,17 +588,38 @@ export function setCurrentSessionById(sessionId: string): Session | null {
  * Save the full LLM message array to the current session directory as messages.json.
  * This preserves tool calls, tool results, and all message metadata for perfect resume.
  */
+/**
+ * Maximum number of LLM messages persisted to messages.json. Capping the persisted
+ * array bounds both the per-turn write size and cumulative growth (so a long session
+ * no longer rewrites an ever-larger array each turn). Only the most recent messages
+ * are kept, which is what session resume needs. Override via the
+ * CALLIOPE_MAX_PERSISTED_MESSAGES env var.
+ */
+const DEFAULT_MAX_PERSISTED_MESSAGES = 1000;
+
+function getMaxPersistedMessages(): number {
+  const raw = process.env.CALLIOPE_MAX_PERSISTED_MESSAGES;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+  }
+  return DEFAULT_MAX_PERSISTED_MESSAGES;
+}
+
 export function saveMessageHistory(messages: unknown[]): void {
   const session = getCurrentSession();
   if (!session) return;
 
   try {
+    const cap = getMaxPersistedMessages();
+    const toPersist = messages.length > cap ? messages.slice(-cap) : messages;
+
     const messagesFile = path.join(paths.currentSession, 'messages.json');
-    writeJSON(messagesFile, messages);
+    writeJSON(messagesFile, toPersist);
 
     // Update session metadata
     const sessionFile = path.join(paths.currentSession, 'session.json');
-    session.messageCount = messages.length;
+    session.messageCount = toPersist.length;
     session.lastAccessedAt = new Date().toISOString();
     writeJSON(sessionFile, session);
   } catch {

--- a/tests/agterm-branching.test.ts
+++ b/tests/agterm-branching.test.ts
@@ -15,6 +15,7 @@ vi.mock('fs', () => ({
   writeFileSync: vi.fn(),
   readFileSync: vi.fn(),
   unlinkSync: vi.fn(),
+  renameSync: vi.fn(),
 }));
 
 // Import after mocks
@@ -254,7 +255,7 @@ describe('Branch Creation', () => {
 
     // The last writeFileSync should be the state file
     const stateWrites = vi.mocked(fs.writeFileSync).mock.calls.filter(
-      call => String(call[0]).endsWith('state.json')
+      call => String(call[0]).includes('state.json')
     );
     expect(stateWrites.length).toBe(1);
 
@@ -409,7 +410,7 @@ describe('Branch Switching', () => {
     switchBranch(TEST_SESSION, 'target', []);
 
     const stateWrites = vi.mocked(fs.writeFileSync).mock.calls.filter(
-      call => String(call[0]).endsWith('state.json')
+      call => String(call[0]).includes('state.json')
     );
     expect(stateWrites.length).toBe(1);
 
@@ -641,7 +642,7 @@ describe('Branch Deletion', () => {
     deleteBranch(TEST_SESSION, 'to-remove');
 
     const stateWrites = vi.mocked(fs.writeFileSync).mock.calls.filter(
-      call => String(call[0]).endsWith('state.json')
+      call => String(call[0]).includes('state.json')
     );
     expect(stateWrites.length).toBe(1);
 
@@ -703,7 +704,7 @@ describe('Branch Renaming', () => {
     expect(result).toBe(true);
 
     const stateWrites = vi.mocked(fs.writeFileSync).mock.calls.filter(
-      call => String(call[0]).endsWith('state.json')
+      call => String(call[0]).includes('state.json')
     );
     const savedState = JSON.parse(stateWrites[0][1] as string) as BranchState;
     expect(savedState.branches['b1'].name).toBe('new-name');
@@ -732,7 +733,7 @@ describe('Branch Renaming', () => {
     expect(result).toBe(true);
 
     const stateWrites = vi.mocked(fs.writeFileSync).mock.calls.filter(
-      call => String(call[0]).endsWith('state.json')
+      call => String(call[0]).includes('state.json')
     );
     const savedState = JSON.parse(stateWrites[0][1] as string) as BranchState;
     expect(savedState.branches['main'].name).toBe('trunk');

--- a/tests/auto-checkpoint.test.ts
+++ b/tests/auto-checkpoint.test.ts
@@ -162,6 +162,7 @@ describe('createCheckpoint', () => {
   it('should create checkpoint for write_file and return hash', () => {
     mockExecFileSync.mockImplementation((_cmd: unknown, args: string[]) => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
       if (args[0] === 'status') return 'M modified.txt\n';
       if (args[0] === 'add') return '';
       if (args[0] === 'diff') return 'some staged diff\n';
@@ -176,6 +177,7 @@ describe('createCheckpoint', () => {
   it('should create checkpoint for shell command and return hash', () => {
     mockExecFileSync.mockImplementation((_cmd: unknown, args: string[]) => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
       if (args[0] === 'status') return 'M file.txt\n';
       if (args[0] === 'add') return '';
       if (args[0] === 'diff') return 'some diff\n';
@@ -190,6 +192,7 @@ describe('createCheckpoint', () => {
   it('should create checkpoint for unknown tool using tool name as summary', () => {
     mockExecFileSync.mockImplementation((_cmd: unknown, args: string[]) => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
       if (args[0] === 'status') return 'M file.txt\n';
       if (args[0] === 'add') return '';
       if (args[0] === 'diff') return 'some diff\n';
@@ -204,6 +207,7 @@ describe('createCheckpoint', () => {
   it('should return null when git commit throws', () => {
     mockExecFileSync.mockImplementation((_cmd: unknown, args: string[]) => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
       if (args[0] === 'status') return 'M file.txt\n';
       if (args[0] === 'add') return '';
       if (args[0] === 'diff') return 'some diff\n';
@@ -216,6 +220,7 @@ describe('createCheckpoint', () => {
   it('should increment checkpoint count on success', () => {
     mockExecFileSync.mockImplementation((_cmd: unknown, args: string[]) => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
       if (args[0] === 'status') return 'M file.txt\n';
       if (args[0] === 'add') return '';
       if (args[0] === 'diff') return 'some diff\n';
@@ -249,6 +254,7 @@ describe('revertToLastCheckpoint', () => {
     // Set up mock to create a checkpoint first
     mockExecFileSync.mockImplementation((_cmd: unknown, args: string[]) => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
       if (args[0] === 'status') return 'M file.txt\n';
       if (args[0] === 'add') return '';
       if (args[0] === 'diff') return 'some diff\n';
@@ -264,6 +270,7 @@ describe('revertToLastCheckpoint', () => {
   it('should return false when git reset throws', () => {
     mockExecFileSync.mockImplementation((_cmd: unknown, args: string[]) => {
       if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo\n';
       if (args[0] === 'status') return 'M file.txt\n';
       if (args[0] === 'add') return '';
       if (args[0] === 'diff') return 'some diff\n';
@@ -273,6 +280,44 @@ describe('revertToLastCheckpoint', () => {
       return '';
     });
     createCheckpoint('write_file', { path: 'test.txt' });
+    expect(revertToLastCheckpoint()).toBe(false);
+  });
+
+  it('should reset against the captured repo root, not live cwd', () => {
+    const resetCalls: string[][] = [];
+    mockExecFileSync.mockImplementation((_cmd: unknown, args: string[], opts: { cwd: string }) => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return '/repo-a\n';
+      if (args[0] === 'status') return 'M file.txt\n';
+      if (args[0] === 'add') return '';
+      if (args[0] === 'diff') return 'some diff\n';
+      if (args[0] === 'commit') return '';
+      if (args[0] === 'rev-parse' && args[1] === '--short') return 'abc1234\n';
+      if (args[0] === 'reset') { resetCalls.push([opts.cwd, ...args]); return ''; }
+      return '';
+    });
+    createCheckpoint('write_file', { path: 'test.txt' });
+    expect(revertToLastCheckpoint()).toBe(true);
+    // The hard reset must run in the captured root, pinned to the checkpoint repo.
+    expect(resetCalls).toEqual([['/repo-a', 'reset', '--hard', 'abc1234']]);
+  });
+
+  it('should be a no-op when the stored repo root no longer matches', () => {
+    let toplevel = '/repo-a\n';
+    mockExecFileSync.mockImplementation((_cmd: unknown, args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--is-inside-work-tree') return 'true\n';
+      if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') return toplevel;
+      if (args[0] === 'status') return 'M file.txt\n';
+      if (args[0] === 'add') return '';
+      if (args[0] === 'diff') return 'some diff\n';
+      if (args[0] === 'commit') return '';
+      if (args[0] === 'rev-parse' && args[1] === '--short') return 'abc1234\n';
+      if (args[0] === 'reset') throw new Error('should not reset on mismatch');
+      return '';
+    });
+    createCheckpoint('write_file', { path: 'test.txt' });
+    // Simulate the cwd moving to a different repo before the revert.
+    toplevel = '/repo-b\n';
     expect(revertToLastCheckpoint()).toBe(false);
   });
 });
@@ -304,23 +349,21 @@ describe('getCheckpointStats', () => {
 });
 
 // ---------------------------------------------------------------------------
-// isGitRepo caching behavior
+// isGitRepo re-evaluation (must not memoize across cwd changes)
 // ---------------------------------------------------------------------------
 
-describe('isGitRepo caching', () => {
-  it('should cache the git repo result after first call', () => {
-    // First call fails (not a git repo)
+describe('isGitRepo re-evaluation', () => {
+  it('should re-evaluate git-repo status on each call (no stale memoization)', () => {
+    // First call: not a git repo.
     mockExecFileSync.mockImplementationOnce(() => { throw new Error('not a git repo'); });
-    // shouldCheckpoint will cache _isGitRepo = false
-    const result1 = shouldCheckpoint('write_file', { path: 'test.txt' });
-    expect(result1).toBe(false);
+    expect(shouldCheckpoint('write_file', { path: 'test.txt' })).toBe(false);
 
-    // Second call (mockExecFileSync would return 'true' but cache says false)
+    // After a cwd change the dir IS a git repo: the prior "false" must not stick.
     mockExecFileSync.mockReturnValue('true\n');
-    const result2 = shouldCheckpoint('write_file', { path: 'test.txt' });
-    // Still false because _isGitRepo is cached as false from fresh module
-    // (Actually after vi.resetModules() + re-import, cache is reset)
-    // This just tests the flow doesn't crash
-    expect(typeof result2).toBe('boolean');
+    expect(shouldCheckpoint('write_file', { path: 'test.txt' })).toBe(true);
+
+    // And the reverse: a dir that stops being a repo must flip back to false.
+    mockExecFileSync.mockImplementation(() => { throw new Error('not a git repo'); });
+    expect(shouldCheckpoint('write_file', { path: 'test.txt' })).toBe(false);
   });
 });

--- a/tests/branching-extended.test.ts
+++ b/tests/branching-extended.test.ts
@@ -21,6 +21,7 @@ vi.mock('fs', () => ({
   writeFileSync: vi.fn(),
   readFileSync: vi.fn(),
   unlinkSync: vi.fn(),
+  renameSync: vi.fn(),
 }));
 
 import {

--- a/tests/idle-eviction.test.ts
+++ b/tests/idle-eviction.test.ts
@@ -232,7 +232,7 @@ describe('idle-eviction', () => {
       expect(getEvictionStats().enabled).toBe(false);
     });
 
-    it('should increment evictionCount after evictions', () => {
+    it('should increment evictionCount once per idle period', () => {
       const baseCount = getEvictionStats().evictionCount;
 
       configureEviction({
@@ -245,11 +245,10 @@ describe('idle-eviction', () => {
       vi.advanceTimersByTime(1500);
       const stats = getEvictionStats();
       // At 500ms: idle=500 < 1000, no eviction
-      // At 1000ms: idle=1000 >= 1000, eviction
-      // At 1500ms: idle=1500 >= 1000, eviction
-      // But callbacks from prior tests are still registered and may trigger additional evictions
-      // Just verify the count increased
-      expect(stats.evictionCount).toBeGreaterThan(baseCount);
+      // At 1000ms: idle=1000 >= 1000, eviction (latch set)
+      // At 1500ms: still idle but latched, no further eviction
+      // Latch ensures exactly one eviction event for this idle period.
+      expect(stats.evictionCount).toBe(baseCount + 1);
     });
 
     it('should report correct idle duration', () => {
@@ -335,12 +334,10 @@ describe('idle-eviction', () => {
       startMonitor();
 
       vi.advanceTimersByTime(1500);
-      // Should only fire once per check, not 4 times (original + 3 extra)
-      // At 1500ms with 500ms interval: check at 500, 1000, 1500
-      // Eviction happens at 1000ms and 1500ms (idle >= 1000)
+      // With stacking, a single idle period would fire many times. With a single
+      // interval plus the once-per-idle-period latch, eviction fires exactly once.
       const evictCalls = cb.mock.calls.filter(([a]: [string]) => a === 'evict');
-      // With stacking, we'd see far more calls. With a single interval, we expect 2 checks that trigger eviction.
-      expect(evictCalls.length).toBe(2);
+      expect(evictCalls.length).toBe(1);
     });
   });
 
@@ -364,7 +361,7 @@ describe('idle-eviction', () => {
       expect(cb).toHaveBeenCalledWith('evict');
     });
 
-    it('should trigger eviction repeatedly on subsequent checks while still idle', () => {
+    it('should fire eviction exactly once while remaining idle (latched)', () => {
       const cb = vi.fn();
       onEviction(cb);
 
@@ -376,10 +373,33 @@ describe('idle-eviction', () => {
       });
 
       vi.advanceTimersByTime(3000);
-      // Checks at 500, 1000, 1500, 2000, 2500, 3000
-      // Evictions at 1000, 1500, 2000, 2500, 3000 (5 times)
+      // Checks at 500, 1000, 1500, 2000, 2500, 3000.
+      // Eviction fires once at 1000ms; the latch suppresses all later ticks.
       const evictCalls = cb.mock.calls.filter(([a]: [string]) => a === 'evict');
-      expect(evictCalls.length).toBe(5);
+      expect(evictCalls.length).toBe(1);
+    });
+
+    it('should evict again in a new idle period after activity resets the latch', () => {
+      const cb = vi.fn();
+      onEviction(cb);
+
+      configureEviction({
+        enabled: true,
+        idleThresholdMs: 1000,
+        checkIntervalMs: 500,
+        autoSaveOnEvict: false,
+      });
+
+      // First idle period -> one eviction.
+      vi.advanceTimersByTime(1500);
+      expect(cb.mock.calls.filter(([a]: [string]) => a === 'evict').length).toBe(1);
+
+      // Activity resets the latch and the idle clock.
+      recordActivity();
+
+      // Second idle period -> one more eviction.
+      vi.advanceTimersByTime(1500);
+      expect(cb.mock.calls.filter(([a]: [string]) => a === 'evict').length).toBe(2);
     });
   });
 

--- a/tests/session-state.test.ts
+++ b/tests/session-state.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for the session-state cluster.
+ *
+ * Covers issue #152: autoCompress must not emit a message array with an
+ * orphaned tool_use/tool_result across the keep boundary (would 400 on the
+ * next provider call). Issues #151 (auto-checkpoint) and #153 (idle-eviction)
+ * are covered in tests/auto-checkpoint.test.ts and tests/idle-eviction.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { autoCompress, configureAutoCompressor, resetAutoCompressorState } from '../src/auto-compressor.js';
+import { validateMessageHistory } from '../src/summarization.js';
+import type { Message as LLMMessage, LLMProvider } from '../src/types.js';
+
+// Provider is never actually called when useLlm is false (heuristic path),
+// but the import graph still resolves it, so mock it to a no-op.
+vi.mock('../src/providers/index.js', () => ({
+  chat: vi.fn(),
+  selectProvider: vi.fn((p: string) => p),
+  getAvailableProviders: vi.fn(() => []),
+}));
+
+const provider = 'anthropic' as unknown as LLMProvider;
+
+// Filler text large enough to push the conversation past the trigger threshold.
+const filler = 'lorem ipsum dolor sit amet '.repeat(40);
+
+function fillerPair(i: number): LLMMessage[] {
+  return [
+    { role: 'user', content: `request ${i}: ${filler}` },
+    { role: 'assistant', content: `reply ${i}: ${filler}` },
+  ];
+}
+
+describe('autoCompress tool-pairing at keep boundary (#152)', () => {
+  beforeEach(() => {
+    configureAutoCompressor({
+      enabled: true,
+      triggerThreshold: 50,
+      targetThreshold: 25,
+      preserveRecent: 2,
+      useLlm: false, // force heuristic summary, no provider call
+      compressionModel: undefined,
+    });
+    resetAutoCompressorState();
+    vi.clearAllMocks();
+  });
+
+  it('does not orphan a tool_use/tool_result pair straddling the boundary', async () => {
+    // 8 filler messages, then an assistant tool_use immediately followed by its
+    // tool_result. With preserveRecent=2, the raw positional cut keeps the last
+    // two messages — the tool_use and its result are the last two, so the cut
+    // would land right before the tool_use (safe here) OR, by adding one more
+    // trailing message, we force the result into the kept tail without its use.
+    const messages: LLMMessage[] = [
+      ...fillerPair(0),
+      ...fillerPair(1),
+      ...fillerPair(2),
+      ...fillerPair(3), // 8 messages so far
+      {
+        role: 'assistant',
+        content: `running a tool ${filler}`,
+        toolCalls: [{ id: 'call_1', name: 'read_file', arguments: { path: '/x' } }],
+      },
+      { role: 'tool', toolCallId: 'call_1', content: `tool output ${filler}` },
+      { role: 'user', content: `follow-up ${filler}` },
+    ];
+    // preserveRecent=2 keeps [tool_result, follow-up user] — the tool_result's
+    // assistant tool_use (index 8) lands in toSummarize => orphaned result.
+
+    const result = await autoCompress(messages, 4000, provider);
+
+    expect(result.compressed).toBe(true);
+
+    // The compressed output must already be free of orphaned tool blocks:
+    // validating it again is a no-op.
+    expect(validateMessageHistory(result.messages)).toEqual(result.messages);
+
+    // Concretely, no role:'tool' message survives without its tool_use.
+    const toolIds = new Set(
+      result.messages.flatMap(m =>
+        m.role === 'assistant' && m.toolCalls ? m.toolCalls.map(t => t.id) : [],
+      ),
+    );
+    for (const m of result.messages) {
+      if (m.role === 'tool') {
+        expect(toolIds.has(m.toolCallId as string)).toBe(true);
+      }
+    }
+  });
+
+  it('keeps a complete tool_use/result pair intact when both fall in the kept tail', async () => {
+    // Happy path: the pair is fully inside the preserved window, so nothing is
+    // stripped and the pairing survives compression.
+    const messages: LLMMessage[] = [
+      ...fillerPair(0),
+      ...fillerPair(1),
+      ...fillerPair(2),
+      ...fillerPair(3),
+      ...fillerPair(4), // 10 filler messages
+      {
+        role: 'assistant',
+        content: `running a tool ${filler}`,
+        toolCalls: [{ id: 'call_keep', name: 'read_file', arguments: { path: '/y' } }],
+      },
+      { role: 'tool', toolCallId: 'call_keep', content: `tool output ${filler}` },
+    ];
+
+    // preserveRecent=2 keeps exactly [assistant tool_use, tool_result].
+    const result = await autoCompress(messages, 4000, provider);
+
+    expect(result.compressed).toBe(true);
+    expect(validateMessageHistory(result.messages)).toEqual(result.messages);
+
+    // The pair is preserved: both the tool_use and its result are present.
+    const hasUse = result.messages.some(
+      m => m.role === 'assistant' && m.toolCalls?.some(t => t.id === 'call_keep'),
+    );
+    const hasResult = result.messages.some(
+      m => m.role === 'tool' && m.toolCallId === 'call_keep',
+    );
+    expect(hasUse).toBe(true);
+    expect(hasResult).toBe(true);
+  });
+});

--- a/tests/storage-extended.test.ts
+++ b/tests/storage-extended.test.ts
@@ -272,14 +272,19 @@ describe('listSessions', () => {
 });
 
 describe('deleteSession', () => {
-  it('should delete an existing session directory', () => {
+  it('should delete an existing session directory by its session id', () => {
     initStorage();
+    // Session dirs are named ${date}_${project}, NOT by the session id.
     const dirName = '2025-01-15_del-project';
     const sessionDir = path.join(paths.sessions, dirName);
     fs.mkdirSync(sessionDir, { recursive: true });
-    fs.writeFileSync(path.join(sessionDir, 'session.json'), '{}');
+    const sessionId = 'session_del_123';
+    fs.writeFileSync(
+      path.join(sessionDir, 'session.json'),
+      JSON.stringify({ id: sessionId })
+    );
 
-    const result = deleteSession(dirName);
+    const result = deleteSession(sessionId);
     expect(result).toBe(true);
     expect(fs.existsSync(sessionDir)).toBe(false);
   });

--- a/tests/storage-integrity.test.ts
+++ b/tests/storage-integrity.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Storage integrity regression tests.
+ *
+ * Covers code-review fixes:
+ *   #148 - deleteSession resolves the session dir by ID, not raw path join.
+ *   #149 - atomic temp-file+rename for JSON persistence (no truncated reads).
+ *   #150 - chat.log rotation + bounded messages.json write amplification.
+ *
+ * Paths are monkey-patched to a temp dir, mirroring tests/storage-extended.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  paths,
+  getOrCreateSession,
+  deleteSession,
+  addChatMessage,
+  getChatHistory,
+  saveMessageHistory,
+  loadMessageHistory,
+} from '../src/storage.js';
+
+let tmpRoot: string;
+let origPaths: Record<string, string>;
+
+function patchPaths(root: string): void {
+  origPaths = { ...paths };
+  paths.root = root;
+  paths.config = path.join(root, 'config.json');
+  paths.sessions = path.join(root, 'sessions');
+  paths.currentSession = path.join(root, 'sessions', 'current');
+  paths.todos = path.join(root, 'todos');
+  paths.globalTodos = path.join(root, 'todos', 'global.json');
+  paths.projectTodos = path.join(root, 'todos', 'by-project');
+  paths.templates = path.join(root, 'templates');
+  paths.planTemplates = path.join(root, 'templates', 'plans');
+  paths.plugins = path.join(root, 'plugins');
+  paths.history = path.join(root, 'history');
+  paths.commandHistory = path.join(root, 'history', 'commands.txt');
+}
+
+function restorePaths(): void {
+  if (origPaths) {
+    Object.assign(paths, origPaths);
+  }
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-integrity-test-'));
+  patchPaths(tmpRoot);
+});
+
+afterEach(() => {
+  restorePaths();
+  delete process.env.CALLIOPE_CHAT_LOG_MAX_BYTES;
+  delete process.env.CALLIOPE_MAX_PERSISTED_MESSAGES;
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// ============================================================================
+// #148 - deleteSession by ID
+// ============================================================================
+
+describe('deleteSession (#148)', () => {
+  it('deletes a real ${date}_${project} session directory by its session id', () => {
+    const session = getOrCreateSession('/some/project/alpha');
+
+    // The on-disk dir is named by date+project, NOT by the session id.
+    const dirs = fs
+      .readdirSync(paths.sessions, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name !== 'current')
+      .map((e) => e.name);
+    expect(dirs.length).toBe(1);
+    expect(dirs[0]).not.toBe(session.id); // proves the raw join would have missed it
+    const realDir = path.join(paths.sessions, dirs[0]);
+    expect(fs.existsSync(realDir)).toBe(true);
+
+    const result = deleteSession(session.id);
+
+    expect(result).toBe(true);
+    expect(fs.existsSync(realDir)).toBe(false);
+  });
+
+  it('returns false (without throwing) for a non-existent session id', () => {
+    getOrCreateSession('/some/project/beta');
+    expect(deleteSession('session_does_not_exist')).toBe(false);
+  });
+});
+
+// ============================================================================
+// #149 - atomic JSON writes
+// ============================================================================
+
+describe('atomic JSON writes (#149)', () => {
+  it('persists valid messages.json and round-trips them (happy path)', () => {
+    getOrCreateSession('/some/project/gamma');
+    const messages = [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'yo' }];
+
+    saveMessageHistory(messages);
+
+    expect(loadMessageHistory()).toEqual(messages);
+  });
+
+  it('leaves the previously persisted JSON intact and readable after a failed write', () => {
+    getOrCreateSession('/some/project/delta');
+    const good = [{ role: 'user', content: 'keep me' }];
+    saveMessageHistory(good);
+
+    const messagesFile = path.join(paths.currentSession, 'messages.json');
+    const before = fs.readFileSync(messagesFile, 'utf-8');
+
+    // Simulate a crash mid-write: stub JSON.stringify to throw on the next call.
+    const origStringify = JSON.stringify;
+    let calls = 0;
+    (JSON as { stringify: typeof JSON.stringify }).stringify = ((...args: Parameters<typeof JSON.stringify>) => {
+      calls += 1;
+      if (calls === 1) throw new Error('boom: serialization failed mid-write');
+      return origStringify(...args);
+    }) as typeof JSON.stringify;
+
+    try {
+      // saveMessageHistory swallows errors, so this must not throw...
+      expect(() => saveMessageHistory([{ role: 'user', content: 'partial' }])).not.toThrow();
+    } finally {
+      (JSON as { stringify: typeof JSON.stringify }).stringify = origStringify;
+    }
+
+    // ...and the original file must be untouched (never truncated) and still parseable.
+    const after = fs.readFileSync(messagesFile, 'utf-8');
+    expect(after).toBe(before);
+    expect(loadMessageHistory()).toEqual(good);
+
+    // No stray temp files left behind in the session dir.
+    const leftover = fs
+      .readdirSync(paths.currentSession)
+      .filter((name) => name.includes('.tmp'));
+    expect(leftover).toEqual([]);
+  });
+});
+
+// ============================================================================
+// #150 - chat.log rotation + bounded messages.json
+// ============================================================================
+
+describe('chat.log rotation (#150)', () => {
+  it('rotates chat.log to chat.log.1 once it exceeds the configured cap', () => {
+    process.env.CALLIOPE_CHAT_LOG_MAX_BYTES = '200'; // tiny cap to force rotation
+    getOrCreateSession('/some/project/epsilon');
+
+    const chatLog = path.join(paths.currentSession, 'chat.log');
+    const rotated = `${chatLog}.1`;
+
+    // Append enough messages to blow past the 200-byte cap.
+    for (let i = 0; i < 20; i++) {
+      addChatMessage({ role: 'user', content: `message number ${i} with some padding text` });
+    }
+
+    expect(fs.existsSync(rotated)).toBe(true);
+    // Active log stays bounded (well under 2x cap after a fresh rotation).
+    expect(fs.statSync(chatLog).size).toBeLessThan(400 + 200);
+  });
+
+  it('does not rotate while under the cap (happy path) and history still reads back', () => {
+    process.env.CALLIOPE_CHAT_LOG_MAX_BYTES = String(5 * 1024 * 1024);
+    getOrCreateSession('/some/project/zeta');
+
+    addChatMessage({ role: 'user', content: 'hello' });
+    addChatMessage({ role: 'assistant', content: 'hi there' });
+
+    const rotated = path.join(paths.currentSession, 'chat.log.1');
+    expect(fs.existsSync(rotated)).toBe(false);
+
+    const history = getChatHistory();
+    expect(history.map((m) => m.content)).toEqual(['hello', 'hi there']);
+  });
+});
+
+describe('messages.json cap (#150)', () => {
+  it('caps the persisted array to the most recent N and resume still works', () => {
+    process.env.CALLIOPE_MAX_PERSISTED_MESSAGES = '5';
+    const session = getOrCreateSession('/some/project/eta');
+
+    const messages = Array.from({ length: 12 }, (_, i) => ({ role: 'user', content: `m${i}` }));
+    saveMessageHistory(messages);
+
+    const loaded = loadMessageHistory();
+    expect(Array.isArray(loaded)).toBe(true);
+    expect(loaded!.length).toBe(5);
+    // Most recent messages are retained (m7..m11).
+    expect(loaded).toEqual(messages.slice(-5));
+
+    // session.json messageCount reflects the persisted (capped) count.
+    const sessionFile = path.join(paths.currentSession, 'session.json');
+    const meta = JSON.parse(fs.readFileSync(sessionFile, 'utf-8'));
+    expect(meta.messageCount).toBe(5);
+    expect(meta.id).toBe(session.id);
+  });
+
+  it('persists everything when under the cap (happy path)', () => {
+    process.env.CALLIOPE_MAX_PERSISTED_MESSAGES = '100';
+    getOrCreateSession('/some/project/theta');
+
+    const messages = [{ role: 'user', content: 'a' }, { role: 'assistant', content: 'b' }];
+    saveMessageHistory(messages);
+
+    expect(loadMessageHistory()).toEqual(messages);
+  });
+});


### PR DESCRIPTION
Closes #148, #149, #150, #151, #152, #153.

- #148 deleteSession resolves the {date}_{project} dir by id instead of a raw
  path join (UI delete now works).
- #149 atomic temp-file+rename for messages/session/branch/checkpoint writes so
  a crash or concurrent instance can't truncate JSON state.
- #150 cap/rotate chat.log; avoid unbounded growth.
- #151 auto-checkpoint captures repo root at checkpoint time (no stale isGitRepo
  memoization across cwd changes; no reset --hard against the wrong repo).
- #152 autoCompress validates tool_use/result pairing at the keep boundary.
- #153 idle-eviction latches so auto-save/evict fires once per idle period.
