### PR TITLE
fix(anthropic): cap non-streaming max_tokens to avoid SDK timeout error

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -214,10 +214,14 @@ export async function chatAnthropic(
     }
   }
 
-  // Non-streaming request
+  // Non-streaming request. The SDK rejects create() when max_tokens is large
+  // enough to risk the 10-minute request timeout — and output caps are now
+  // model-aware (up to 64K-128K, #144). Cap the non-streaming path at a safe
+  // ceiling; the interactive streaming path above keeps the full model output.
+  const NONSTREAM_MAX_TOKENS = 8192;
   const response = await client.messages.create({
     model,
-    max_tokens: dynamicMaxTokens,
+    max_tokens: Math.min(dynamicMaxTokens, NONSTREAM_MAX_TOKENS),
     system: systemMessage ? getTextContent(systemMessage.content) : '',
     messages: anthropicMessages,
     tools: anthropicTools.length > 0 ? anthropicTools : undefined,

--- a/tests/providers-anthropic.test.ts
+++ b/tests/providers-anthropic.test.ts
@@ -746,6 +746,11 @@ describe('adaptive thinking + refusal stop reason (#147)', () => {
     expect(lastCreateParams?.thinking).toBeUndefined();
   });
 
+  it('caps non-streaming max_tokens to a timeout-safe ceiling', async () => {
+    await chatAnthropic([{ role: 'user', content: 'hi' }], [], 'claude-opus-4-8');
+    expect(lastCreateParams?.max_tokens as number).toBeLessThanOrEqual(8192);
+  });
+
   it('maps the refusal stop reason to an error finish', async () => {
     mockCreateResponse = {
       content: [],


### PR DESCRIPTION
Caught by running the built CLI headless against the live API: @anthropic-ai/sdk
0.104 rejects a non-streaming messages.create() when max_tokens is large enough
to risk the 10-minute request timeout. Since output caps became model-aware
(#144, up to 64K-128K), the headless/non-streaming path hit this. Cap the
non-streaming request at 8192 (its pre-release value); the interactive streaming
path keeps the full model-aware output.
