### PR TITLE
Raise coverage to 93.7% lines and enforce a 90% floor

### DIFF
--- a/tests/fleet-enabled.test.ts
+++ b/tests/fleet-enabled.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Enabled-path tests for src/fleet.ts.
+ *
+ * The default (disabled) path lives in fleet.test.ts. Here the config mock
+ * reports fleet.enabled=true and the scuttlebot module is mocked so we can
+ * assert the lazy single load, the enable/disable persistence, and that every
+ * fleet* helper delegates to the underlying client only while active.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const cfg = vi.hoisted(() => ({
+  store: { fleet: { enabled: true } } as Record<string, any>,
+  setCalls: [] as Array<[string, any]>,
+}));
+
+const sb = vi.hoisted(() => {
+  const client = {
+    initialize: vi.fn(async () => true),
+    isEnabled: vi.fn(() => true),
+    getStatus: vi.fn(() => ({ enabled: true, connected: true, nick: 'n', config: undefined })),
+    startPolling: vi.fn(),
+    postOnline: vi.fn(async () => {}),
+    postOffline: vi.fn(async () => {}),
+    postMessage: vi.fn(async () => {}),
+    mirrorToolCall: vi.fn(async () => {}),
+    mirrorAssistant: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+  };
+  return { client, state: { loadCount: 0 } };
+});
+
+vi.mock('../src/config.js', () => ({
+  default: {
+    get: (key: string) => cfg.store[key],
+    set: (key: string, val: any) => {
+      cfg.setCalls.push([key, val]);
+      cfg.store[key] = val;
+    },
+  },
+}));
+
+vi.mock('../src/scuttlebot/index.js', () => {
+  sb.state.loadCount++;
+  return { scuttlebotClient: sb.client };
+});
+
+import {
+  fleetConfigured,
+  fleetActive,
+  fleetInit,
+  fleetEnable,
+  fleetDisable,
+  fleetStatus,
+  fleetStartPolling,
+  fleetPostOnline,
+  fleetPostOffline,
+  fleetPostMessage,
+  fleetMirrorToolCall,
+  fleetMirrorAssistant,
+} from '../src/fleet.js';
+
+beforeEach(() => {
+  cfg.store = { fleet: { enabled: true } };
+  cfg.setCalls = [];
+  vi.clearAllMocks();
+  sb.client.initialize.mockResolvedValue(true);
+  sb.client.isEnabled.mockReturnValue(true);
+});
+
+afterEach(async () => {
+  // Reset fleet.ts module-level `client` so tests do not bleed into each other.
+  await fleetDisable();
+});
+
+describe('configuration state', () => {
+  it('reports configured when fleet.enabled is true', () => {
+    expect(fleetConfigured()).toBe(true);
+  });
+
+  it('is inactive until a client is loaded', () => {
+    expect(fleetActive()).toBe(false);
+  });
+});
+
+describe('fleetInit', () => {
+  it('lazily loads the scuttlebot module and initializes the client', async () => {
+    const ok = await fleetInit('sess-1', '/repo');
+    expect(ok).toBe(true);
+    expect(sb.state.loadCount).toBe(1);
+    expect(sb.client.initialize).toHaveBeenCalledWith('sess-1', '/repo');
+    expect(fleetActive()).toBe(true);
+  });
+
+  it('reuses the already-loaded client on subsequent calls (single load)', async () => {
+    await fleetInit('sess-1', '/repo');
+    await fleetInit('sess-2', '/repo');
+    expect(sb.state.loadCount).toBe(1); // module imported once
+    expect(sb.client.initialize).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns false and never initializes when not configured', async () => {
+    cfg.store.fleet = { enabled: false };
+    const ok = await fleetInit('sess', '/repo');
+    expect(ok).toBe(false);
+    expect(sb.client.initialize).not.toHaveBeenCalled();
+  });
+});
+
+describe('fleetEnable', () => {
+  it('persists enabled=true and connects', async () => {
+    cfg.store.fleet = { enabled: false };
+    const ok = await fleetEnable('sess', '/repo');
+
+    expect(ok).toBe(true);
+    expect(cfg.setCalls).toContainEqual(['fleet', { enabled: true }]);
+    expect(cfg.store.fleet.enabled).toBe(true);
+    expect(sb.client.initialize).toHaveBeenCalledWith('sess', '/repo');
+  });
+
+  it('propagates a failed connection result', async () => {
+    sb.client.initialize.mockResolvedValueOnce(false);
+    const ok = await fleetEnable('sess', '/repo');
+    expect(ok).toBe(false);
+  });
+
+  it('merges into existing fleet config rather than replacing it', async () => {
+    cfg.store.fleet = { enabled: false, channel: 'ops' };
+    await fleetEnable('sess', '/repo');
+    expect(cfg.store.fleet).toEqual({ enabled: true, channel: 'ops' });
+  });
+});
+
+describe('active pass-throughs', () => {
+  beforeEach(async () => {
+    await fleetInit('sess', '/repo');
+  });
+
+  it('fleetStatus returns the client status', () => {
+    expect(fleetStatus()).toEqual({ enabled: true, connected: true, nick: 'n', config: undefined });
+  });
+
+  it('fleetStartPolling forwards the handler', () => {
+    const handler = vi.fn();
+    fleetStartPolling(handler);
+    expect(sb.client.startPolling).toHaveBeenCalledWith(handler);
+  });
+
+  it('fleetPostOnline delegates to the client', () => {
+    fleetPostOnline();
+    expect(sb.client.postOnline).toHaveBeenCalled();
+  });
+
+  it('fleetPostMessage forwards the text', () => {
+    fleetPostMessage('hello fleet');
+    expect(sb.client.postMessage).toHaveBeenCalledWith('hello fleet');
+  });
+
+  it('fleetMirrorToolCall forwards name and args', async () => {
+    await fleetMirrorToolCall('shell', { command: 'ls' });
+    expect(sb.client.mirrorToolCall).toHaveBeenCalledWith('shell', { command: 'ls' });
+  });
+
+  it('fleetMirrorAssistant forwards the content', () => {
+    fleetMirrorAssistant('thinking...');
+    expect(sb.client.mirrorAssistant).toHaveBeenCalledWith('thinking...');
+  });
+
+  it('fleetPostOffline posts offline and disconnects', async () => {
+    await fleetPostOffline();
+    expect(sb.client.postOffline).toHaveBeenCalled();
+    expect(sb.client.disconnect).toHaveBeenCalled();
+  });
+});
+
+describe('fleetDisable', () => {
+  it('tears down the client and persists enabled=false', async () => {
+    await fleetInit('sess', '/repo');
+    expect(fleetActive()).toBe(true);
+
+    await fleetDisable();
+
+    expect(sb.client.postOffline).toHaveBeenCalled();
+    expect(sb.client.disconnect).toHaveBeenCalled();
+    expect(cfg.store.fleet.enabled).toBe(false);
+    expect(fleetActive()).toBe(false);
+    expect(fleetStatus()).toBeNull();
+  });
+
+  it('still persists enabled=false when no client was ever loaded', async () => {
+    await fleetDisable();
+    expect(cfg.store.fleet.enabled).toBe(false);
+    expect(sb.client.disconnect).not.toHaveBeenCalled();
+  });
+});
+
+describe('inactive helpers are no-ops', () => {
+  it('never touch the client when inactive', () => {
+    // isEnabled returns false -> fleetActive() is false even if a client exists.
+    sb.client.isEnabled.mockReturnValue(false);
+
+    expect(fleetStatus()).toBeNull();
+    fleetStartPolling(vi.fn());
+    fleetPostOnline();
+    fleetPostMessage('x');
+    fleetMirrorAssistant('y');
+
+    expect(sb.client.startPolling).not.toHaveBeenCalled();
+    expect(sb.client.postOnline).not.toHaveBeenCalled();
+    expect(sb.client.postMessage).not.toHaveBeenCalled();
+    expect(sb.client.mirrorAssistant).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -1005,4 +1005,88 @@ describe('chatOllama', () => {
       expect(body.stream).toBe(true);
     });
   });
+
+  // --------------------------------------------------------------------------
+  // Text-based (XML-style) tool call parsing — parseTextToolCalls
+  // Used when a model emits <function=...> markup instead of structured
+  // tool_calls (e.g. some quantized/older models).
+  // --------------------------------------------------------------------------
+
+  describe('text-based tool call parsing', () => {
+    it('extracts an XML-style tool call and strips it from the content (non-streaming)', async () => {
+      const data = makeResponse({
+        message: {
+          role: 'assistant',
+          content:
+            'Let me read that <function=read_file><parameter=path>/tmp/a.txt</parameter></function>',
+          tool_calls: undefined,
+        },
+      });
+      vi.mocked(fetch).mockResolvedValueOnce(mockFetchResponse(data) as Response);
+
+      const result = await chatOllama([{ role: 'user', content: 'Read it' }], [sampleTool], 'llama3.3');
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('read_file');
+      expect(result.toolCalls![0].arguments).toEqual({ path: '/tmp/a.txt' });
+      expect(result.content).toBe('Let me read that');
+      expect(result.finishReason).toBe('tool_use');
+    });
+
+    it('JSON-parses numeric/typed parameter values, keeping non-JSON as strings', async () => {
+      const data = makeResponse({
+        message: {
+          role: 'assistant',
+          content:
+            '<function=set><parameter=count>5</parameter><parameter=label>hello world</parameter></function>',
+          tool_calls: undefined,
+        },
+      });
+      vi.mocked(fetch).mockResolvedValueOnce(mockFetchResponse(data) as Response);
+
+      const result = await chatOllama([{ role: 'user', content: 'Set' }], [sampleTool], 'llama3.3');
+
+      expect(result.toolCalls![0].arguments).toEqual({ count: 5, label: 'hello world' });
+    });
+
+    it('leaves content untouched when the <function= marker has no complete block', async () => {
+      const data = makeResponse({
+        message: {
+          role: 'assistant',
+          content: 'thinking about <function=incomplete but never closed',
+          tool_calls: undefined,
+        },
+      });
+      vi.mocked(fetch).mockResolvedValueOnce(mockFetchResponse(data) as Response);
+
+      const result = await chatOllama([{ role: 'user', content: 'Hi' }], [sampleTool], 'llama3.3');
+
+      expect(result.toolCalls).toBeUndefined();
+      expect(result.content).toBe('thinking about <function=incomplete but never closed');
+      expect(result.finishReason).toBe('stop');
+    });
+
+    it('parses XML-style tool calls out of streamed content', async () => {
+      const chunks = [
+        JSON.stringify({ message: { role: 'assistant', content: 'ok ' }, done: false }),
+        JSON.stringify({
+          message: {
+            role: 'assistant',
+            content: '<function=read_file><parameter=path>/etc/hosts</parameter></function>',
+          },
+          done: false,
+        }),
+        JSON.stringify({ message: { role: 'assistant', content: '' }, done: true, prompt_eval_count: 2, eval_count: 4 }),
+      ];
+      vi.mocked(fetch).mockResolvedValueOnce(mockStreamResponse(chunks) as unknown as Response);
+
+      const result = await chatOllama([{ role: 'user', content: 'Read' }], [sampleTool], 'llama3.3', () => {});
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls![0].name).toBe('read_file');
+      expect(result.toolCalls![0].arguments).toEqual({ path: '/etc/hosts' });
+      expect(result.content).toBe('ok');
+      expect(result.finishReason).toBe('tool_use');
+    });
+  });
 });

--- a/tests/sandbox-routing.test.ts
+++ b/tests/sandbox-routing.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for src/sandbox/index.ts — mode-routing helpers.
+ *
+ * The two backends (Docker / native) and the config are mocked so we can drive
+ * the full mode x availability matrix and assert which backend each helper
+ * selects, including the 'auto' fallbacks (Docker unavailable -> native ->
+ * unsandboxed).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  mode: undefined as string | undefined,
+  docker: false,
+  native: false,
+}));
+
+vi.mock('../src/config.js', () => ({
+  default: { get: (key: string) => (key === 'sandboxMode' ? state.mode : undefined) },
+}));
+vi.mock('../src/sandbox/docker.js', () => ({ isDockerAvailable: () => state.docker }));
+vi.mock('../src/sandbox/native.js', () => ({ isNativeSandboxAvailable: () => state.native }));
+
+import { getSandboxMode, selectCodeSandbox, shouldUseNativeSandbox } from '../src/sandbox/index.js';
+
+beforeEach(() => {
+  state.mode = undefined;
+  state.docker = false;
+  state.native = false;
+});
+
+describe('getSandboxMode', () => {
+  it('defaults to auto when unset', () => {
+    expect(getSandboxMode()).toBe('auto');
+  });
+
+  it('returns the configured mode', () => {
+    state.mode = 'docker';
+    expect(getSandboxMode()).toBe('docker');
+  });
+});
+
+describe('selectCodeSandbox', () => {
+  it('honours explicit docker / native / off modes regardless of availability', () => {
+    state.mode = 'docker';
+    expect(selectCodeSandbox()).toBe('docker');
+    state.mode = 'native';
+    expect(selectCodeSandbox()).toBe('native');
+    state.mode = 'off';
+    expect(selectCodeSandbox()).toBe('unsandboxed');
+  });
+
+  it('auto prefers Docker when available', () => {
+    state.mode = 'auto';
+    state.docker = true;
+    state.native = true;
+    expect(selectCodeSandbox()).toBe('docker');
+  });
+
+  it('auto falls back to the native sandbox when Docker is unavailable', () => {
+    state.mode = 'auto';
+    state.docker = false;
+    state.native = true;
+    expect(selectCodeSandbox()).toBe('native');
+  });
+
+  it('auto falls back to unsandboxed when no backend is available', () => {
+    state.mode = 'auto';
+    state.docker = false;
+    state.native = false;
+    expect(selectCodeSandbox()).toBe('unsandboxed');
+  });
+});
+
+describe('shouldUseNativeSandbox', () => {
+  it('skips for off and docker modes', () => {
+    state.mode = 'off';
+    expect(shouldUseNativeSandbox()).toBe('skip');
+    state.mode = 'docker';
+    expect(shouldUseNativeSandbox()).toBe('skip');
+  });
+
+  it('requires the native sandbox for native mode', () => {
+    state.mode = 'native';
+    expect(shouldUseNativeSandbox()).toBe('require');
+  });
+
+  it('auto uses the native sandbox when available, else skips', () => {
+    state.mode = 'auto';
+    state.native = true;
+    expect(shouldUseNativeSandbox()).toBe('use');
+    state.native = false;
+    expect(shouldUseNativeSandbox()).toBe('skip');
+  });
+});

--- a/tests/scuttlebot-client.test.ts
+++ b/tests/scuttlebot-client.test.ts
@@ -1,0 +1,512 @@
+/**
+ * Tests for src/scuttlebot/client.ts — the orchestration layer.
+ *
+ * We mock at the module seams rather than the socket: the IRC client, the HTTP
+ * client and the channel-config resolver are all replaced with fakes that
+ * record calls and expose the wired-up envelope / instruction handlers. `node:fs`
+ * is stubbed so the ~/.config/scuttlebot-relay.env fallback is always empty,
+ * keeping the config resolution deterministic across machines.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Fakes (hoisted so vi.mock factories can reference them) ─────────────
+const H = vi.hoisted(() => {
+  const irc = { instances: [] as any[], connectImpl: null as null | (() => Promise<void>), connected: true };
+
+  class FakeIRC {
+    opts: any;
+    envelopeHandlers: Array<(env: any, channel: string) => void> = [];
+    instructionHandlers: Array<(text: string, from: string, channel: string) => void> = [];
+    sends: Array<{ method: string; channel: string; arg: any }> = [];
+    _connected = false;
+    constructor(opts: any) {
+      this.opts = opts;
+      irc.instances.push(this);
+    }
+    onEnvelope(h: (env: any, channel: string) => void) {
+      this.envelopeHandlers.push(h);
+    }
+    onInstruction(h: (text: string, from: string, channel: string) => void) {
+      this.instructionHandlers.push(h);
+    }
+    async connect() {
+      if (irc.connectImpl) await irc.connectImpl();
+      this._connected = irc.connected;
+    }
+    sendEnvelope(channel: string, env: any) {
+      this.sends.push({ method: 'sendEnvelope', channel, arg: env });
+    }
+    sendRaw(channel: string, text: string) {
+      this.sends.push({ method: 'sendRaw', channel, arg: text });
+    }
+    async disconnect() {
+      this._connected = false;
+    }
+    isConnected() {
+      return this._connected;
+    }
+    emitEnvelope(env: any, channel: string) {
+      for (const h of this.envelopeHandlers) h(env, channel);
+    }
+    emitInstruction(text: string, from: string, channel: string) {
+      for (const h of this.instructionHandlers) h(text, from, channel);
+    }
+  }
+
+  const http = { instances: [] as any[], registerImpl: null as null | ((...a: any[]) => any) };
+
+  class FakeHTTP {
+    config: any;
+    calls: Array<{ method: string; args: any[] }> = [];
+    constructor(config: any) {
+      this.config = config;
+      http.instances.push(this);
+    }
+    async register(nick: string, type?: string, channels?: string[]) {
+      this.calls.push({ method: 'register', args: [nick, type, channels] });
+      if (http.registerImpl) return http.registerImpl(nick, type, channels);
+      return { nick: `${nick}-reg`, passphrase: 'pp' };
+    }
+    async deleteAgent(nick: string) {
+      this.calls.push({ method: 'deleteAgent', args: [nick] });
+    }
+    async touchPresence(channel: string, nick: string) {
+      this.calls.push({ method: 'touchPresence', args: [channel, nick] });
+    }
+    async healthCheck() {
+      return true;
+    }
+  }
+
+  const cfg = {
+    resolved: {
+      channel: 'general',
+      channels: ['general'] as string[],
+      url: undefined as string | undefined,
+      ircAddr: undefined as string | undefined,
+      tls: undefined as boolean | undefined,
+      nick: undefined as string | undefined,
+    },
+  };
+
+  return { irc, FakeIRC, http, FakeHTTP, cfg };
+});
+
+vi.mock('../src/scuttlebot/irc-client.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return { ...actual, ScuttlebotIRCClient: H.FakeIRC };
+});
+vi.mock('../src/scuttlebot/http-client.js', () => ({ ScuttlebotHTTPClient: H.FakeHTTP }));
+vi.mock('../src/scuttlebot/config.js', () => ({
+  resolveChannelConfig: (_cwd: string, _channel?: string, _channels?: string) => H.cfg.resolved,
+}));
+vi.mock('node:fs', () => {
+  const readFileSync = () => {
+    throw new Error('ENOENT');
+  };
+  return { readFileSync, default: { readFileSync } };
+});
+
+import { ScuttlebotClient } from '../src/scuttlebot/client.js';
+
+// ── Env management ──────────────────────────────────────────────────────
+const ENV_KEYS = [
+  'SCUTTLEBOT_PASSPHRASE',
+  'SCUTTLEBOT_TOKEN',
+  'SCUTTLEBOT_URL',
+  'SCUTTLEBOT_CHANNEL',
+  'SCUTTLEBOT_CHANNELS',
+  'SCUTTLEBOT_IRC_ADDR',
+  'SCUTTLEBOT_NICK',
+];
+let savedEnv: Record<string, string | undefined> = {};
+
+const lastIrc = () => H.irc.instances[H.irc.instances.length - 1] as InstanceType<typeof H.FakeIRC>;
+const lastHttp = () => H.http.instances[H.http.instances.length - 1] as InstanceType<typeof H.FakeHTTP>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  H.irc.instances.length = 0;
+  H.irc.connectImpl = null;
+  H.irc.connected = true;
+  H.http.instances.length = 0;
+  H.http.registerImpl = null;
+  H.cfg.resolved = { channel: 'general', channels: ['general'], url: undefined, ircAddr: undefined, tls: undefined, nick: undefined };
+
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// initialize
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('initialize', () => {
+  it('returns false when neither passphrase nor token is configured', async () => {
+    const c = new ScuttlebotClient();
+    await expect(c.initialize('sess', '/tmp/proj')).resolves.toBe(false);
+    expect(c.isEnabled()).toBe(false);
+    expect(H.irc.instances).toHaveLength(0);
+  });
+
+  it('connects in pre-registered mode using the configured nick', async () => {
+    process.env.SCUTTLEBOT_PASSPHRASE = 'pass-abc';
+    process.env.SCUTTLEBOT_NICK = 'calliope';
+    const c = new ScuttlebotClient();
+
+    const ok = await c.initialize('sess', '/tmp/proj');
+
+    expect(ok).toBe(true);
+    expect(c.isEnabled()).toBe(true);
+    const irc = lastIrc();
+    expect(irc.opts.nick).toBe('calliope');
+    expect(irc.opts.passphrase).toBe('pass-abc');
+    expect(irc.opts.channels).toEqual(['#general']);
+    // No url+token, so no HTTP client for presence.
+    expect(H.http.instances).toHaveLength(0);
+    // Announces presence with an agent.hello envelope.
+    const hello = irc.sends.find((s) => s.method === 'sendEnvelope');
+    expect(hello?.arg.type).toBe('agent.hello');
+    expect(hello?.arg.from).toBe('calliope');
+  });
+
+  it('defaults the nick to "calliope" when nothing else provides one', async () => {
+    process.env.SCUTTLEBOT_PASSPHRASE = 'pass-abc';
+    const c = new ScuttlebotClient();
+    await c.initialize('sess', '/tmp/proj');
+    expect(lastIrc().opts.nick).toBe('calliope');
+  });
+
+  it('creates an HTTP presence client in pre-registered mode when url+token are set', async () => {
+    process.env.SCUTTLEBOT_PASSPHRASE = 'pass-abc';
+    process.env.SCUTTLEBOT_NICK = 'calliope';
+    process.env.SCUTTLEBOT_URL = 'http://relay';
+    process.env.SCUTTLEBOT_TOKEN = 'tok';
+    const c = new ScuttlebotClient();
+
+    await c.initialize('sess', '/tmp/proj');
+
+    const http = lastHttp();
+    expect(http.calls.some((call) => call.method === 'touchPresence')).toBe(true);
+
+    // Heartbeat: advancing 60s issues another presence touch.
+    const before = http.calls.filter((call) => call.method === 'touchPresence').length;
+    await vi.advanceTimersByTimeAsync(60_000);
+    const after = http.calls.filter((call) => call.method === 'touchPresence').length;
+    expect(after).toBeGreaterThan(before);
+
+    await c.disconnect();
+  });
+
+  it('registers dynamically via HTTP when a token (but no passphrase) is set', async () => {
+    process.env.SCUTTLEBOT_TOKEN = 'tok';
+    process.env.SCUTTLEBOT_URL = 'http://relay';
+    const c = new ScuttlebotClient();
+
+    const ok = await c.initialize('sess', '/tmp/My Project!');
+
+    expect(ok).toBe(true);
+    const http = lastHttp();
+    const reg = http.calls.find((call) => call.method === 'register');
+    expect(reg).toBeDefined();
+    // Session nick: calliope-<sanitized-basename>-<8 hex>
+    expect(reg!.args[0]).toMatch(/^calliope-My-Project-[0-9a-f]{8}$/);
+    expect(reg!.args[1]).toBe('worker');
+    // IRC uses the credentials returned by register().
+    expect(lastIrc().opts.nick).toBe(`${reg!.args[0]}-reg`);
+  });
+
+  it('uses SCUTTLEBOT_NICK verbatim (sanitized) in dynamic mode', async () => {
+    process.env.SCUTTLEBOT_TOKEN = 'tok';
+    process.env.SCUTTLEBOT_URL = 'http://relay';
+    process.env.SCUTTLEBOT_NICK = 'my bot!';
+    const c = new ScuttlebotClient();
+
+    await c.initialize('sess', '/tmp/proj');
+    const reg = lastHttp().calls.find((call) => call.method === 'register')!;
+    expect(reg.args[0]).toBe('my-bot');
+  });
+
+  it('returns false in dynamic mode when the URL is missing', async () => {
+    process.env.SCUTTLEBOT_TOKEN = 'tok'; // token but no url
+    const c = new ScuttlebotClient();
+
+    await expect(c.initialize('sess', '/tmp/proj')).resolves.toBe(false);
+    expect(c.isEnabled()).toBe(false);
+    expect(H.irc.instances).toHaveLength(0);
+  });
+
+  it('swallows connection errors and reports disabled', async () => {
+    process.env.SCUTTLEBOT_PASSPHRASE = 'pass-abc';
+    H.irc.connectImpl = async () => {
+      throw new Error('connection refused');
+    };
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const c = new ScuttlebotClient();
+
+    const ok = await c.initialize('sess', '/tmp/proj');
+
+    expect(ok).toBe(false);
+    expect(c.isEnabled()).toBe(false);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('passes tls:true when the IRC address is on port 6697', async () => {
+    process.env.SCUTTLEBOT_PASSPHRASE = 'pass-abc';
+    process.env.SCUTTLEBOT_IRC_ADDR = 'irc.relay:6697';
+    const c = new ScuttlebotClient();
+
+    await c.initialize('sess', '/tmp/proj');
+    expect(lastIrc().opts.tls).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Posting + mirroring
+// ═══════════════════════════════════════════════════════════════════════
+
+async function enabledClient(nick = 'calliope'): Promise<ScuttlebotClient> {
+  process.env.SCUTTLEBOT_PASSPHRASE = 'pass-abc';
+  process.env.SCUTTLEBOT_NICK = nick;
+  const c = new ScuttlebotClient();
+  await c.initialize('sess', '/tmp/proj');
+  lastIrc().sends.length = 0; // clear the hello envelope
+  return c;
+}
+
+describe('postMessage', () => {
+  it('sends plain text to the primary channel', async () => {
+    const c = await enabledClient();
+    await c.postMessage('build finished');
+    const send = lastIrc().sends.find((s) => s.method === 'sendRaw');
+    expect(send).toEqual({ method: 'sendRaw', channel: 'general', arg: 'build finished' });
+  });
+
+  it('redacts secrets before posting', async () => {
+    const c = await enabledClient();
+    await c.postMessage('token deadbeefdeadbeefdeadbeefdeadbeef key sk-ABC123 API_KEY=hunter2 bearer xy.z');
+    const arg = lastIrc().sends.find((s) => s.method === 'sendRaw')!.arg as string;
+    expect(arg).not.toContain('deadbeefdeadbeefdeadbeefdeadbeef');
+    expect(arg).not.toContain('sk-ABC123');
+    expect(arg).not.toContain('hunter2');
+    expect(arg).toContain('[REDACTED]');
+    expect(arg).toContain('bearer [REDACTED]');
+  });
+
+  it('is a no-op when disabled', async () => {
+    const c = new ScuttlebotClient();
+    await c.postMessage('dropped');
+    expect(H.irc.instances).toHaveLength(0);
+  });
+});
+
+describe('presence envelopes', () => {
+  it('postOnline emits agent.hello and postOffline emits agent.bye', async () => {
+    const c = await enabledClient();
+
+    await c.postOnline();
+    await c.postOffline();
+
+    const types = lastIrc()
+      .sends.filter((s) => s.method === 'sendEnvelope')
+      .map((s) => s.arg.type);
+    expect(types).toContain('agent.hello');
+    expect(types).toContain('agent.bye');
+  });
+});
+
+describe('mirrorToolCall', () => {
+  it('formats the tool name with a path / command / pattern argument', async () => {
+    const c = await enabledClient();
+
+    await c.mirrorToolCall('read_file', { path: '/tmp/a.txt' });
+    await c.mirrorToolCall('shell', { command: 'ls -la' });
+    await c.mirrorToolCall('grep', { pattern: 'TODO' });
+
+    const args = lastIrc()
+      .sends.filter((s) => s.method === 'sendRaw')
+      .map((s) => s.arg);
+    expect(args).toContain('read_file /tmp/a.txt');
+    expect(args).toContain('shell ls -la');
+    expect(args).toContain('grep TODO');
+  });
+
+  it('sends just the tool name when there are no recognised args', async () => {
+    const c = await enabledClient();
+    await c.mirrorToolCall('list_dir');
+    expect(lastIrc().sends.find((s) => s.method === 'sendRaw')!.arg).toBe('list_dir');
+  });
+
+  it('is a no-op when disabled', async () => {
+    const c = new ScuttlebotClient();
+    await c.mirrorToolCall('shell', { command: 'ls' });
+    expect(H.irc.instances).toHaveLength(0);
+  });
+});
+
+describe('mirrorAssistant', () => {
+  it('passes short messages through unchanged', async () => {
+    const c = await enabledClient();
+    await c.mirrorAssistant('done');
+    expect(lastIrc().sends.find((s) => s.method === 'sendRaw')!.arg).toBe('done');
+  });
+
+  it('truncates messages longer than 200 characters', async () => {
+    const c = await enabledClient();
+    await c.mirrorAssistant('x'.repeat(300));
+    const arg = lastIrc().sends.find((s) => s.method === 'sendRaw')!.arg as string;
+    expect(arg).toHaveLength(200);
+    expect(arg.endsWith('...')).toBe(true);
+  });
+
+  it('is a no-op when disabled', async () => {
+    const c = new ScuttlebotClient();
+    await c.mirrorAssistant('hi');
+    expect(H.irc.instances).toHaveLength(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Instruction routing
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('startPolling / instruction routing', () => {
+  it('routes a task.create envelope to the instruction handler', async () => {
+    const c = await enabledClient();
+    const got: string[] = [];
+    c.startPolling((instr) => got.push(instr));
+
+    lastIrc().emitEnvelope(
+      { v: 1, type: 'task.create', id: 'x', from: 'boss', ts: 1, payload: { instruction: 'do X' } },
+      '#general',
+    );
+    expect(got).toEqual(['do X']);
+  });
+
+  it('falls back through prompt / text / stringified payload', async () => {
+    const c = await enabledClient();
+    const got: string[] = [];
+    c.startPolling((instr) => got.push(instr));
+    const irc = lastIrc();
+
+    irc.emitEnvelope({ v: 1, type: 'task.create', id: '1', from: 'b', ts: 1, payload: { prompt: 'P' } }, '#g');
+    irc.emitEnvelope({ v: 1, type: 'task.create', id: '2', from: 'b', ts: 1, payload: { text: 'T' } }, '#g');
+    irc.emitEnvelope({ v: 1, type: 'task.create', id: '3', from: 'b', ts: 1, payload: { other: 'O' } }, '#g');
+
+    expect(got[0]).toBe('P');
+    expect(got[1]).toBe('T');
+    expect(got[2]).toBe(JSON.stringify({ other: 'O' }));
+  });
+
+  it('ignores non-task.create envelopes', async () => {
+    const c = await enabledClient();
+    const got: string[] = [];
+    c.startPolling((instr) => got.push(instr));
+
+    lastIrc().emitEnvelope({ v: 1, type: 'agent.hello', id: 'x', from: 'boss', ts: 1 }, '#general');
+    expect(got).toHaveLength(0);
+  });
+
+  it('strips the addressing prefix from human instructions', async () => {
+    const c = await enabledClient('calliope');
+    const got: string[] = [];
+    c.startPolling((instr) => got.push(instr));
+
+    lastIrc().emitInstruction('calliope: please ship it', 'alice', '#general');
+    expect(got).toEqual(['please ship it']);
+  });
+
+  it('stopPolling detaches the handler', async () => {
+    const c = await enabledClient();
+    const got: string[] = [];
+    c.startPolling((instr) => got.push(instr));
+    c.stopPolling();
+
+    lastIrc().emitEnvelope(
+      { v: 1, type: 'task.create', id: 'x', from: 'boss', ts: 1, payload: { instruction: 'do X' } },
+      '#general',
+    );
+    expect(got).toHaveLength(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Status + disconnect
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('getStatus', () => {
+  it('reports a disabled, unconnected shape before initialization', () => {
+    const c = new ScuttlebotClient();
+    expect(c.getStatus()).toEqual({ enabled: false, config: undefined, nick: undefined, connected: false });
+  });
+
+  it('reflects the live connection once initialized', async () => {
+    const c = await enabledClient('calliope');
+    const status = c.getStatus();
+    expect(status.enabled).toBe(true);
+    expect(status.nick).toBe('calliope');
+    expect(status.connected).toBe(true);
+    expect(status.config?.channel).toBe('general');
+  });
+});
+
+describe('disconnect', () => {
+  it('deletes the session registration in dynamic mode', async () => {
+    process.env.SCUTTLEBOT_TOKEN = 'tok';
+    process.env.SCUTTLEBOT_URL = 'http://relay';
+    const c = new ScuttlebotClient();
+    await c.initialize('sess', '/tmp/proj');
+    const irc = lastIrc();
+    const http = lastHttp();
+
+    await c.disconnect();
+
+    // Bye envelope sent, IRC disconnected, registration deleted.
+    expect(irc.sends.some((s) => s.method === 'sendEnvelope' && s.arg.type === 'agent.bye')).toBe(true);
+    expect(http.calls.some((call) => call.method === 'deleteAgent')).toBe(true);
+    expect(c.isEnabled()).toBe(false);
+    expect(c.getStatus().connected).toBe(false);
+  });
+
+  it('does not delete a registration it did not create (pre-registered mode)', async () => {
+    process.env.SCUTTLEBOT_PASSPHRASE = 'pass-abc';
+    process.env.SCUTTLEBOT_URL = 'http://relay';
+    process.env.SCUTTLEBOT_TOKEN = 'tok';
+    const c = new ScuttlebotClient();
+    await c.initialize('sess', '/tmp/proj');
+    const http = lastHttp();
+
+    await c.disconnect();
+
+    expect(http.calls.some((call) => call.method === 'deleteAgent')).toBe(false);
+  });
+
+  it('stops the presence heartbeat', async () => {
+    process.env.SCUTTLEBOT_PASSPHRASE = 'pass-abc';
+    process.env.SCUTTLEBOT_NICK = 'calliope';
+    process.env.SCUTTLEBOT_URL = 'http://relay';
+    process.env.SCUTTLEBOT_TOKEN = 'tok';
+    const c = new ScuttlebotClient();
+    await c.initialize('sess', '/tmp/proj');
+    const http = lastHttp();
+
+    await c.disconnect();
+    const after = http.calls.filter((call) => call.method === 'touchPresence').length;
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(http.calls.filter((call) => call.method === 'touchPresence').length).toBe(after);
+  });
+});

--- a/tests/scuttlebot-http-client.test.ts
+++ b/tests/scuttlebot-http-client.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for src/scuttlebot/http-client.ts
+ *
+ * The HTTP client only touches the network through the global `fetch`, which
+ * we stub. Each test asserts the request shape (URL, method, headers, body)
+ * and the return / error behaviour for register / rotate / delete / presence
+ * / health-check.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ScuttlebotHTTPClient, type ScuttlebotConfig } from '../src/scuttlebot/http-client.js';
+
+const mockFetch = vi.fn();
+
+const config: ScuttlebotConfig = {
+  url: 'http://localhost:3000',
+  token: 'tok-123',
+  ircAddr: '127.0.0.1:6667',
+  channel: 'general',
+  channels: ['general', 'release'],
+};
+
+function jsonResponse(body: unknown, init: { status?: number; ok?: boolean; statusText?: string } = {}) {
+  const status = init.status ?? 200;
+  return {
+    ok: init.ok ?? (status >= 200 && status < 300),
+    status,
+    statusText: init.statusText ?? '',
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('register', () => {
+  it('returns credentials on 201 Created and sends a normalized channel list', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ credentials: { nick: 'agent-1', passphrase: 'pw' } }, { status: 201 }),
+    );
+    const client = new ScuttlebotHTTPClient(config);
+
+    const creds = await client.register('agent-1', 'worker', ['ops', '#eng']);
+
+    expect(creds).toEqual({ nick: 'agent-1', passphrase: 'pw' });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/agents/register');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers.Authorization).toBe('Bearer tok-123');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({ nick: 'agent-1', type: 'worker', channels: ['#ops', '#eng'] });
+  });
+
+  it('defaults the agent type to worker and uses config channels when none passed', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ credentials: { nick: 'a', passphrase: 'p' } }, { status: 201 }),
+    );
+    const client = new ScuttlebotHTTPClient(config);
+
+    await client.register('a');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.type).toBe('worker');
+    expect(body.channels).toEqual(['#general', '#release']);
+  });
+
+  it('rotates when the nick already exists (409 Conflict)', async () => {
+    const client = new ScuttlebotHTTPClient(config);
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse('conflict', { status: 409 }))
+      .mockResolvedValueOnce(jsonResponse({ passphrase: 'rotated-pw' }, { status: 200 }));
+
+    const creds = await client.register('agent-1');
+
+    expect(creds).toEqual({ nick: 'agent-1', passphrase: 'rotated-pw' });
+    expect(mockFetch.mock.calls[1][0]).toBe('http://localhost:3000/v1/agents/agent-1/rotate');
+  });
+
+  it('throws with server detail on an unexpected status', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse('boom', { status: 500, statusText: 'Internal Server Error' }),
+    );
+    const client = new ScuttlebotHTTPClient(config);
+
+    await expect(client.register('agent-1')).rejects.toThrow(
+      /Registration failed: 500 Internal Server Error — boom/,
+    );
+  });
+});
+
+describe('rotate', () => {
+  it('returns the new passphrase for an existing nick', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ passphrase: 'fresh' }));
+    const client = new ScuttlebotHTTPClient(config);
+
+    const creds = await client.rotate('agent-9');
+
+    expect(creds).toEqual({ nick: 'agent-9', passphrase: 'fresh' });
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/agents/agent-9/rotate');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers.Authorization).toBe('Bearer tok-123');
+  });
+
+  it('throws when the rotate request fails', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse('nope', { status: 403, statusText: 'Forbidden' }),
+    );
+    const client = new ScuttlebotHTTPClient(config);
+
+    await expect(client.rotate('agent-9')).rejects.toThrow(/Rotate failed: 403 Forbidden — nope/);
+  });
+});
+
+describe('deleteAgent', () => {
+  it('issues a DELETE with the bearer token', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse('', { status: 204 }));
+    const client = new ScuttlebotHTTPClient(config);
+
+    await client.deleteAgent('agent-1');
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/agents/agent-1');
+    expect(opts.method).toBe('DELETE');
+    expect(opts.headers.Authorization).toBe('Bearer tok-123');
+  });
+
+  it('swallows network errors (best-effort cleanup)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+    const client = new ScuttlebotHTTPClient(config);
+
+    await expect(client.deleteAgent('agent-1')).resolves.toBeUndefined();
+  });
+});
+
+describe('touchPresence', () => {
+  it('posts presence for a nick, stripping the leading # from the channel', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse('', { status: 200 }));
+    const client = new ScuttlebotHTTPClient(config);
+
+    await client.touchPresence('#general', 'mybot');
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('http://localhost:3000/v1/channels/general/presence');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ nick: 'mybot' });
+  });
+
+  it('does nothing when url or token is missing', async () => {
+    const client = new ScuttlebotHTTPClient({ ...config, url: '', token: '' });
+
+    await client.touchPresence('general', 'mybot');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('swallows presence post errors', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('boom'));
+    const client = new ScuttlebotHTTPClient(config);
+
+    await expect(client.touchPresence('general', 'mybot')).resolves.toBeUndefined();
+  });
+});
+
+describe('healthCheck', () => {
+  it('returns true when the status endpoint responds ok', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse('ok', { status: 200 }));
+    const client = new ScuttlebotHTTPClient(config);
+
+    await expect(client.healthCheck()).resolves.toBe(true);
+    expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:3000/v1/status');
+  });
+
+  it('returns false on a non-ok response', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse('down', { status: 503 }));
+    const client = new ScuttlebotHTTPClient(config);
+
+    await expect(client.healthCheck()).resolves.toBe(false);
+  });
+
+  it('returns false when fetch throws', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('unreachable'));
+    const client = new ScuttlebotHTTPClient(config);
+
+    await expect(client.healthCheck()).resolves.toBe(false);
+  });
+});

--- a/tests/scuttlebot-irc-client.test.ts
+++ b/tests/scuttlebot-irc-client.test.ts
@@ -1,0 +1,703 @@
+/**
+ * Tests for src/scuttlebot/irc-client.ts
+ *
+ * The IRC client talks to a real TCP/TLS socket. We mock `node:net` and
+ * `node:tls` at the module seam: each `createConnection`/`connect` call
+ * returns a hand-rolled fake socket (a minimal EventEmitter that records
+ * every `write()`), and the connect callback is captured rather than fired
+ * so the test drives the SASL handshake deterministically by feeding raw
+ * server lines through the socket's `data` event. Fake timers make the
+ * 30s connect timeout, PING keepalive, reconnect backoff and QUIT drain
+ * instantaneous and race-free.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Socket mock (hoisted so the vi.mock factories can see it) ───────────
+const netMock = vi.hoisted(() => {
+  interface FakeSocket {
+    writes: string[];
+    destroyed: boolean;
+    setEncoding: () => FakeSocket;
+    write: (data: string) => boolean;
+    destroy: () => FakeSocket;
+    on: (event: string, cb: (...a: unknown[]) => void) => FakeSocket;
+    once: (event: string, cb: (...a: unknown[]) => void) => FakeSocket;
+    off: (event: string, cb: (...a: unknown[]) => void) => FakeSocket;
+    removeAllListeners: () => FakeSocket;
+    emit: (event: string, ...args: unknown[]) => boolean;
+    feed: (data: string) => void;
+  }
+
+  const sockets: FakeSocket[] = [];
+  const onConnects: Array<undefined | (() => void)> = [];
+  const tlsFlags: boolean[] = [];
+
+  function makeSocket(): FakeSocket {
+    const handlers: Record<string, Array<(...a: unknown[]) => void>> = {};
+    const socket: FakeSocket = {
+      writes: [],
+      destroyed: false,
+      setEncoding() {
+        return socket;
+      },
+      write(data: string) {
+        socket.writes.push(data);
+        return true;
+      },
+      destroy() {
+        socket.destroyed = true;
+        return socket;
+      },
+      on(event, cb) {
+        (handlers[event] ??= []).push(cb);
+        return socket;
+      },
+      once(event, cb) {
+        const wrap = (...a: unknown[]) => {
+          socket.off(event, wrap);
+          cb(...a);
+        };
+        return socket.on(event, wrap);
+      },
+      off(event, cb) {
+        if (handlers[event]) handlers[event] = handlers[event].filter((f) => f !== cb);
+        return socket;
+      },
+      removeAllListeners() {
+        for (const k of Object.keys(handlers)) delete handlers[k];
+        return socket;
+      },
+      emit(event, ...args) {
+        for (const cb of [...(handlers[event] ?? [])]) cb(...args);
+        return true;
+      },
+      feed(data: string) {
+        socket.emit('data', data);
+      },
+    };
+    return socket;
+  }
+
+  function record(onConnect: undefined | (() => void), tls: boolean): FakeSocket {
+    const s = makeSocket();
+    sockets.push(s);
+    onConnects.push(onConnect);
+    tlsFlags.push(tls);
+    return s;
+  }
+
+  return {
+    sockets,
+    onConnects,
+    tlsFlags,
+    createConnection: (_opts: unknown, onConnect?: () => void) => record(onConnect, false),
+    tlsConnect: (_opts: unknown, onConnect?: () => void) => record(onConnect, true),
+    reset() {
+      sockets.length = 0;
+      onConnects.length = 0;
+      tlsFlags.length = 0;
+    },
+    last() {
+      return {
+        socket: sockets[sockets.length - 1],
+        onConnect: onConnects[onConnects.length - 1],
+      };
+    },
+  };
+});
+
+vi.mock('node:net', () => ({
+  createConnection: netMock.createConnection,
+  default: { createConnection: netMock.createConnection },
+}));
+vi.mock('node:tls', () => ({
+  connect: netMock.tlsConnect,
+  default: { connect: netMock.tlsConnect },
+}));
+
+import {
+  ScuttlebotIRCClient,
+  matchesRecipient,
+  newEnvelope,
+  MessageTypes,
+  type Envelope,
+  type IRCClientOptions,
+} from '../src/scuttlebot/irc-client.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const clients: ScuttlebotIRCClient[] = [];
+
+function makeClient(overrides: Partial<IRCClientOptions> = {}): ScuttlebotIRCClient {
+  const c = new ScuttlebotIRCClient({
+    serverAddr: '127.0.0.1:6667',
+    nick: 'mybot',
+    passphrase: 'secret',
+    channels: ['general'],
+    agentType: 'worker',
+    ...overrides,
+  });
+  clients.push(c);
+  return c;
+}
+
+const written = (s: { writes: string[] }) => s.writes.join('');
+const writtenLines = (s: { writes: string[] }) => written(s).split('\r\n').filter(Boolean);
+
+/** Drive a full successful SASL handshake for the most recently created socket. */
+function driveHandshake(nick = 'mybot'): { socket: ReturnType<typeof netMock.last>['socket'] } {
+  const { socket, onConnect } = netMock.last();
+  onConnect?.();
+  socket.feed(':irc.test CAP * ACK :sasl\r\n');
+  socket.feed('AUTHENTICATE +\r\n');
+  socket.feed(`:irc.test 903 ${nick} :SASL authentication successful\r\n`);
+  socket.feed(`:irc.test 001 ${nick} :Welcome to the network\r\n`);
+  return { socket };
+}
+
+async function connectClient(c: ScuttlebotIRCClient, nick = 'mybot') {
+  const p = c.connect();
+  const { socket } = driveHandshake(nick);
+  await p;
+  return socket;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  netMock.reset();
+});
+
+afterEach(async () => {
+  // Tear down every client so PING intervals and process SIGINT/SIGTERM
+  // listeners never leak across tests.
+  for (const c of clients) {
+    try {
+      const p = c.disconnect();
+      await vi.advanceTimersByTimeAsync(600);
+      await p;
+    } catch {
+      /* already torn down */
+    }
+  }
+  clients.length = 0;
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Pure functions
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('newEnvelope', () => {
+  it('creates a v1 envelope with a generated id and timestamp', () => {
+    const env = newEnvelope('task.create', 'boss');
+    expect(env.v).toBe(1);
+    expect(env.type).toBe('task.create');
+    expect(env.from).toBe('boss');
+    expect(typeof env.id).toBe('string');
+    expect(env.id.length).toBeGreaterThan(0);
+    expect(typeof env.ts).toBe('number');
+    expect(env.to).toBeUndefined();
+    expect(env.payload).toBeUndefined();
+  });
+
+  it('includes to and payload when provided', () => {
+    const env = newEnvelope('task.create', 'boss', {
+      to: ['@workers'],
+      payload: { instruction: 'go' },
+    });
+    expect(env.to).toEqual(['@workers']);
+    expect(env.payload).toEqual({ instruction: 'go' });
+  });
+
+  it('generates unique ids across calls', () => {
+    const a = newEnvelope('x', 'me');
+    const b = newEnvelope('x', 'me');
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe('matchesRecipient', () => {
+  const base = (to?: string[]): Envelope => ({
+    v: 1,
+    type: 'task.create',
+    id: 'id1',
+    from: 'boss',
+    ts: 1,
+    ...(to ? { to } : {}),
+  });
+
+  it('treats an empty or missing recipient list as a broadcast', () => {
+    expect(matchesRecipient(base(), 'anynick', 'worker')).toBe(true);
+    expect(matchesRecipient(base([]), 'anynick', 'worker')).toBe(true);
+  });
+
+  it('matches @all for any agent', () => {
+    expect(matchesRecipient(base(['@all']), 'nick', 'observer')).toBe(true);
+  });
+
+  it('matches agent-type tokens only for that type', () => {
+    expect(matchesRecipient(base(['@workers']), 'n', 'worker')).toBe(true);
+    expect(matchesRecipient(base(['@workers']), 'n', 'operator')).toBe(false);
+    expect(matchesRecipient(base(['@operators']), 'n', 'operator')).toBe(true);
+    expect(matchesRecipient(base(['@orchestrators']), 'n', 'orchestrator')).toBe(true);
+    expect(matchesRecipient(base(['@observers']), 'n', 'observer')).toBe(true);
+  });
+
+  it('matches an @prefix-* glob against the nick prefix', () => {
+    expect(matchesRecipient(base(['@calliope-*']), 'calliope-abc', 'worker')).toBe(true);
+    expect(matchesRecipient(base(['@calliope-*']), 'codex-abc', 'worker')).toBe(false);
+  });
+
+  it('matches a bare nick exactly', () => {
+    expect(matchesRecipient(base(['mybot']), 'mybot', 'worker')).toBe(true);
+    expect(matchesRecipient(base(['someoneelse']), 'mybot', 'worker')).toBe(false);
+  });
+
+  it('scans multiple tokens and returns false when none match', () => {
+    expect(matchesRecipient(base(['@operators', 'other']), 'mybot', 'worker')).toBe(false);
+    expect(matchesRecipient(base(['@operators', 'mybot']), 'mybot', 'worker')).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Connection lifecycle
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('connect', () => {
+  it('completes the SASL handshake and resolves once registered', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+
+    expect(c.isConnected()).toBe(true);
+    const lines = writtenLines(socket);
+    expect(lines).toContain('CAP REQ :sasl');
+    expect(lines).toContain('NICK mybot');
+    expect(lines).toContain('USER mybot 0 * :mybot');
+    expect(lines).toContain('AUTHENTICATE PLAIN');
+    // SASL PLAIN payload: base64 of \0nick\0passphrase
+    const expectedAuth = 'AUTHENTICATE ' + Buffer.from('\0mybot\0secret').toString('base64');
+    expect(lines).toContain(expectedAuth);
+    expect(lines).toContain('CAP END');
+    // Joins its channel after 001
+    expect(lines).toContain('JOIN #general');
+  });
+
+  it('is a no-op when already connected', async () => {
+    const c = makeClient();
+    await connectClient(c);
+    const socketCount = netMock.sockets.length;
+    await c.connect(); // should short-circuit
+    expect(netMock.sockets.length).toBe(socketCount);
+  });
+
+  it('normalizes channel names without a leading # when joining', async () => {
+    const c = makeClient({ channels: ['#ops', 'release'] });
+    const socket = await connectClient(c);
+    const lines = writtenLines(socket);
+    expect(lines).toContain('JOIN #ops');
+    expect(lines).toContain('JOIN #release');
+  });
+
+  it('uses tls.connect for port 6697', async () => {
+    const c = makeClient({ serverAddr: 'irc.test:6697' });
+    const p = c.connect();
+    driveHandshake();
+    await p;
+    expect(netMock.tlsFlags[netMock.tlsFlags.length - 1]).toBe(true);
+  });
+
+  it('uses tls.connect when tls:true is set explicitly', async () => {
+    const c = makeClient({ serverAddr: 'irc.test:6667', tls: true });
+    const p = c.connect();
+    driveHandshake();
+    await p;
+    expect(netMock.tlsFlags[netMock.tlsFlags.length - 1]).toBe(true);
+  });
+
+  it('rejects on connection timeout', async () => {
+    const c = makeClient();
+    const p = c.connect();
+    const rejection = expect(p).rejects.toThrow(/timeout/i);
+    await vi.advanceTimersByTimeAsync(30000);
+    await rejection;
+    expect(c.isConnected()).toBe(false);
+  });
+
+  it('rejects when the socket errors during connect', async () => {
+    const c = makeClient();
+    const p = c.connect();
+    const { socket } = netMock.last();
+    const rejection = expect(p).rejects.toThrow('ECONNREFUSED');
+    socket.emit('error', new Error('ECONNREFUSED'));
+    await rejection;
+    expect(c.isConnected()).toBe(false);
+  });
+
+  it('rejects when SASL authentication fails (904)', async () => {
+    const c = makeClient();
+    const p = c.connect();
+    const { socket, onConnect } = netMock.last();
+    onConnect?.();
+    socket.feed(':irc.test CAP * ACK :sasl\r\n');
+    socket.feed('AUTHENTICATE +\r\n');
+    const rejection = expect(p).rejects.toThrow(/bad password|SASL/i);
+    socket.feed(':irc.test 904 mybot :SASL authentication failed: bad password\r\n');
+    await rejection;
+    expect(c.isConnected()).toBe(false);
+  });
+
+  it('sends CAP END when the server NAKs the sasl capability', async () => {
+    const c = makeClient();
+    c.connect().catch(() => {});
+    const { socket, onConnect } = netMock.last();
+    onConnect?.();
+    socket.feed(':irc.test CAP * NAK :sasl\r\n');
+    expect(writtenLines(socket)).toContain('CAP END');
+  });
+
+  it('defaults to port 6667 when the address has no port', async () => {
+    const c = makeClient({ serverAddr: 'irc.test' });
+    const p = c.connect();
+    driveHandshake();
+    await p;
+    // No port -> not TLS (6667 default), so plain net.createConnection was used.
+    expect(netMock.tlsFlags[netMock.tlsFlags.length - 1]).toBe(false);
+    expect(c.isConnected()).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Sending
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('sending', () => {
+  it('sendEnvelope serializes a JSON envelope to a PRIVMSG', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    socket.writes.length = 0;
+
+    c.sendEnvelope('general', { v: 1, type: MessageTypes.AgentHello, from: 'mybot' });
+    const line = writtenLines(socket).find((l) => l.startsWith('PRIVMSG #general :'));
+    expect(line).toBeDefined();
+    const json = JSON.parse(line!.replace('PRIVMSG #general :', ''));
+    expect(json.type).toBe('agent.hello');
+    expect(json.from).toBe('mybot');
+    expect(json.v).toBe(1);
+  });
+
+  it('sendRaw sends a plain-text PRIVMSG and prefixes the channel with #', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    socket.writes.length = 0;
+
+    c.sendRaw('general', 'hello world');
+    expect(writtenLines(socket)).toContain('PRIVMSG #general :hello world');
+  });
+
+  it('splits multi-line text into separate PRIVMSGs and skips blank lines', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    socket.writes.length = 0;
+
+    c.sendRaw('general', 'line one\n\nline two');
+    const lines = writtenLines(socket);
+    expect(lines).toContain('PRIVMSG #general :line one');
+    expect(lines).toContain('PRIVMSG #general :line two');
+    expect(lines.filter((l) => l === 'PRIVMSG #general :')).toHaveLength(0);
+  });
+
+  it('is a no-op when not connected', () => {
+    const c = makeClient();
+    c.sendRaw('general', 'dropped');
+    // No socket was ever created because connect() was never called.
+    expect(netMock.sockets.length).toBe(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Receiving — envelopes and human chat
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('receiving PRIVMSG envelopes', () => {
+  it('delivers a valid broadcast envelope to envelope handlers', async () => {
+    const c = makeClient();
+    const received: Array<{ env: Envelope; channel: string }> = [];
+    c.onEnvelope((env, channel) => received.push({ env, channel }));
+    const socket = await connectClient(c);
+
+    const env = newEnvelope('task.create', 'boss', { payload: { instruction: 'go' } });
+    socket.feed(`:boss!u@h PRIVMSG #general :${JSON.stringify(env)}\r\n`);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].channel).toBe('#general');
+    expect(received[0].env.type).toBe('task.create');
+    expect((received[0].env.payload as { instruction: string }).instruction).toBe('go');
+  });
+
+  it('drops an envelope addressed to a different recipient', async () => {
+    const c = makeClient();
+    const received: Envelope[] = [];
+    c.onEnvelope((env) => received.push(env));
+    const socket = await connectClient(c);
+
+    const env = newEnvelope('task.create', 'boss', { to: ['@operators'] });
+    socket.feed(`:boss!u@h PRIVMSG #general :${JSON.stringify(env)}\r\n`);
+
+    expect(received).toHaveLength(0);
+  });
+
+  it('ignores PRIVMSGs sent by our own nick', async () => {
+    const c = makeClient();
+    const received: Envelope[] = [];
+    c.onEnvelope((env) => received.push(env));
+    const socket = await connectClient(c);
+
+    const env = newEnvelope('task.create', 'mybot');
+    socket.feed(`:mybot!u@h PRIVMSG #general :${JSON.stringify(env)}\r\n`);
+
+    expect(received).toHaveLength(0);
+  });
+
+  it('treats malformed JSON (missing envelope fields) as human chat, not an envelope', async () => {
+    const c = makeClient();
+    const envs: Envelope[] = [];
+    const instructions: string[] = [];
+    c.onEnvelope((env) => envs.push(env));
+    c.onInstruction((text) => instructions.push(text));
+    const socket = await connectClient(c);
+
+    // Valid JSON object but not a valid envelope (no v/id/from/ts) and mentions the bot.
+    socket.feed(':alice!u@h PRIVMSG #general :{"hello":"mybot"}\r\n');
+
+    expect(envs).toHaveLength(0);
+    expect(instructions).toHaveLength(1);
+  });
+});
+
+describe('receiving human instructions', () => {
+  it('delivers a human message that mentions our nick', async () => {
+    const c = makeClient();
+    const got: Array<{ text: string; from: string; channel: string }> = [];
+    c.onInstruction((text, from, channel) => got.push({ text, from, channel }));
+    const socket = await connectClient(c);
+
+    socket.feed(':alice!u@h PRIVMSG #general :mybot please build it\r\n');
+
+    expect(got).toEqual([{ text: 'mybot please build it', from: 'alice', channel: '#general' }]);
+  });
+
+  it('ignores human messages that do not mention our nick', async () => {
+    const c = makeClient();
+    const got: string[] = [];
+    c.onInstruction((text) => got.push(text));
+    const socket = await connectClient(c);
+
+    socket.feed(':alice!u@h PRIVMSG #general :hello everyone\r\n');
+    expect(got).toHaveLength(0);
+  });
+
+  it('ignores messages from known service bots', async () => {
+    const c = makeClient();
+    const got: string[] = [];
+    c.onInstruction((text) => got.push(text));
+    const socket = await connectClient(c);
+
+    socket.feed(':oracle!u@h PRIVMSG #general :mybot status\r\n');
+    expect(got).toHaveLength(0);
+  });
+
+  it('ignores messages from other agents (agent nick prefixes)', async () => {
+    const c = makeClient();
+    const got: string[] = [];
+    c.onInstruction((text) => got.push(text));
+    const socket = await connectClient(c);
+
+    socket.feed(':claude-worker!u@h PRIVMSG #general :mybot hi\r\n');
+    expect(got).toHaveLength(0);
+  });
+
+  it('does nothing when no instruction handlers are registered', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    // No onInstruction registered — must not throw.
+    expect(() => socket.feed(':alice!u@h PRIVMSG #general :mybot hi\r\n')).not.toThrow();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Protocol edge cases
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('protocol parsing', () => {
+  it('answers a server PING with a PONG', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    socket.writes.length = 0;
+
+    socket.feed('PING :hub.irc.test\r\n');
+    expect(writtenLines(socket)).toContain('PONG :hub.irc.test');
+  });
+
+  it('strips IRCv3 message tags before dispatch', async () => {
+    const c = makeClient();
+    const instructions: string[] = [];
+    c.onInstruction((text) => instructions.push(text));
+    const socket = await connectClient(c);
+
+    socket.feed('@time=2020 :alice!u@h PRIVMSG #general :mybot tagged\r\n');
+    expect(instructions).toEqual(['mybot tagged']);
+  });
+
+  it('ignores a bare tag line with no trailing message', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    // Line is only a tag, no space -> handleLine returns early without throwing.
+    expect(() => socket.feed('@only-a-tag\r\n')).not.toThrow();
+  });
+
+  it('silently ignores NOTICE lines', async () => {
+    const c = makeClient();
+    const instructions: string[] = [];
+    c.onInstruction((text) => instructions.push(text));
+    const socket = await connectClient(c);
+
+    socket.feed(':server NOTICE #general :mybot heads up\r\n');
+    expect(instructions).toHaveLength(0);
+  });
+
+  it('buffers a message split across two data events', async () => {
+    const c = makeClient();
+    const instructions: string[] = [];
+    c.onInstruction((text) => instructions.push(text));
+    const socket = await connectClient(c);
+
+    socket.feed(':alice!u@h PRIVMSG #general :mybot par');
+    expect(instructions).toHaveLength(0); // no line terminator yet
+    socket.feed('tial line\r\n');
+    expect(instructions).toEqual(['mybot partial line']);
+  });
+
+  it('handles \\n-only line endings', async () => {
+    const c = makeClient();
+    const instructions: string[] = [];
+    c.onInstruction((text) => instructions.push(text));
+    const socket = await connectClient(c);
+
+    socket.feed(':alice!u@h PRIVMSG #general :mybot newline only\n');
+    expect(instructions).toEqual(['mybot newline only']);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Keepalive + reconnect
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('keepalive', () => {
+  it('sends a client PING after the keepalive interval and clears it on PONG', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    socket.writes.length = 0;
+
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(writtenLines(socket)).toContain('PING :calliope');
+
+    // Server PONG clears the pending-ping state; the dead-connection timeout
+    // must NOT fire afterwards.
+    socket.feed(':irc.test PONG irc.test :calliope\r\n');
+    socket.writes.length = 0;
+    await vi.advanceTimersByTimeAsync(30000);
+    // A new PING may be issued, but the connection is still alive.
+    expect(c.isConnected()).toBe(true);
+  });
+
+  it('tears down and schedules a reconnect when no PONG arrives', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    const socketsBefore = netMock.sockets.length;
+
+    await vi.advanceTimersByTimeAsync(30000); // PING sent
+    expect(writtenLines(socket)).toContain('PING :calliope');
+    await vi.advanceTimersByTimeAsync(30000); // no PONG -> dead
+    expect(c.isConnected()).toBe(false);
+
+    // Reconnect backoff kicks in.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(netMock.sockets.length).toBeGreaterThan(socketsBefore);
+  });
+});
+
+describe('reconnect', () => {
+  it('reconnects after an unexpected socket close', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    const socketsBefore = netMock.sockets.length;
+
+    socket.emit('close');
+    expect(c.isConnected()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(netMock.sockets.length).toBe(socketsBefore + 1);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Disconnect + exit handling
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('disconnect', () => {
+  it('sends QUIT and stops reconnecting', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+    socket.writes.length = 0;
+
+    const p = c.disconnect();
+    // Simulate the server closing the connection in response to QUIT.
+    socket.emit('close');
+    await p;
+
+    expect(written(socket)).toContain('QUIT :Session ended');
+    expect(c.isConnected()).toBe(false);
+
+    // After disconnect, a close does not trigger a reconnect.
+    const socketsAfter = netMock.sockets.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(netMock.sockets.length).toBe(socketsAfter);
+  });
+
+  it('drains via the timeout when the server never closes', async () => {
+    const c = makeClient();
+    const socket = await connectClient(c);
+
+    const p = c.disconnect();
+    await vi.advanceTimersByTimeAsync(500); // drain timer
+    await p;
+    expect(written(socket)).toContain('QUIT :Session ended');
+  });
+
+  it('is safe to call when never connected', async () => {
+    const c = makeClient();
+    await expect(c.disconnect()).resolves.toBeUndefined();
+  });
+
+  it('registers a SIGINT/SIGTERM handler that QUITs on exit and unregisters on disconnect', async () => {
+    const before = process.listeners('SIGINT');
+    const c = makeClient();
+    const socket = await connectClient(c);
+
+    const added = process.listeners('SIGINT').filter((h) => !before.includes(h));
+    expect(added).toHaveLength(1);
+
+    socket.writes.length = 0;
+    (added[0] as () => void)(); // invoke the exit handler directly (no real signal)
+    expect(written(socket)).toContain('QUIT :Session ended');
+    expect(socket.destroyed).toBe(true);
+
+    const p = c.disconnect();
+    await vi.advanceTimersByTimeAsync(600);
+    await p;
+    // Handler removed after disconnect.
+    expect(process.listeners('SIGINT').filter((h) => !before.includes(h))).toHaveLength(0);
+  });
+});

--- a/tests/tools-web-exec-git.test.ts
+++ b/tests/tools-web-exec-git.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for the web_search, execute_code and git executors in src/tools.ts,
+ * driven through the real executeTool dispatch.
+ *
+ * - `https` is mocked so web_search parses a canned DuckDuckGo HTML page with no
+ *   network access, and we can force the error / timeout branches.
+ * - the sandbox backend is mocked so execute_code's native and unsandboxed
+ *   output-formatting paths run without a real sandbox.
+ * - git's security validations (unknown op, RCE flags, ext:: protocol, commit
+ *   requires -m) short-circuit before any child process is spawned.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// ── https mock (per-test controllable) ──────────────────────────────────
+const httpsMock = vi.hoisted(() => ({ mode: 'success' as 'success' | 'error' | 'timeout', body: '', errMsg: 'boom' }));
+vi.mock('https', () => ({
+  get: (_url: any, _opts: any, cb?: any) => {
+    const { EventEmitter } = require('events');
+    const callback = typeof _opts === 'function' ? _opts : cb;
+    const req: any = new EventEmitter();
+    req.destroy = () => {};
+    req.setTimeout = (_ms: number, onTimeout: () => void) => {
+      if (httpsMock.mode === 'timeout') process.nextTick(onTimeout);
+    };
+    if (httpsMock.mode === 'error') {
+      process.nextTick(() => req.emit('error', new Error(httpsMock.errMsg)));
+      return req;
+    }
+    if (httpsMock.mode === 'success') {
+      const res: any = new EventEmitter();
+      res.statusCode = 200;
+      process.nextTick(() => {
+        callback(res);
+        process.nextTick(() => {
+          res.emit('data', httpsMock.body);
+          res.emit('end');
+        });
+      });
+    }
+    return req;
+  },
+}));
+
+// ── sandbox mock (per-test controllable) ────────────────────────────────
+const sb = vi.hoisted(() => ({
+  strategy: 'unsandboxed' as 'docker' | 'native' | 'unsandboxed',
+  native: { stdout: '', stderr: '', exitCode: 0, sandboxed: true, backend: 'seatbelt' },
+  unsafe: { success: true, stdout: '', stderr: '', exitCode: 0, duration: 5 },
+}));
+vi.mock('../src/sandbox/index.js', () => ({
+  selectCodeSandbox: () => sb.strategy,
+  executeInNativeSandbox: async () => sb.native,
+  executeUnsafe: async () => sb.unsafe,
+  execute: async () => ({ success: true, stdout: '', stderr: '', exitCode: 0, duration: 1, sandboxed: true }),
+  shouldUseNativeSandbox: () => 'skip',
+  isDockerAvailable: () => false,
+  isNativeSandboxAvailable: () => false,
+  getSandboxMode: () => 'off',
+}));
+
+import { executeTool } from '../src/tools.js';
+import { resetScope } from '../src/scope.js';
+import type { ToolCall } from '../src/types.js';
+
+function makeTool(name: string, args: Record<string, unknown>): ToolCall {
+  return { id: `call-${Date.now()}`, name, arguments: args };
+}
+
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-tools-weg-'));
+  resetScope(tmpDir);
+  httpsMock.mode = 'success';
+  httpsMock.body = '';
+  sb.strategy = 'unsandboxed';
+  sb.native = { stdout: '', stderr: '', exitCode: 0, sandboxed: true, backend: 'seatbelt' };
+  sb.unsafe = { success: true, stdout: '', stderr: '', exitCode: 0, duration: 5 };
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// web_search
+// ═══════════════════════════════════════════════════════════════════════
+
+const DDG_HTML = [
+  '<a class="result__a" href="https://a.com">Title A</a>',
+  '<a class="result__snippet">Snippet A</a>',
+  '<a class="result__a" href="https://b.com">Title B</a>',
+  '<a class="result__snippet">Snippet B</a>',
+  '<a class="result__a" href="https://c.com">Title C</a>',
+  '<a class="result__snippet">Snippet C</a>',
+].join('\n');
+
+describe('web_search', () => {
+  it('rejects an empty query before hitting the network', async () => {
+    const r = await executeTool(makeTool('web_search', { query: '   ' }), tmpDir);
+    expect(r.isError).toBe(true);
+    expect(r.result).toContain('query must be a non-empty string');
+  });
+
+  it('parses results from the DuckDuckGo HTML response', async () => {
+    httpsMock.body = DDG_HTML;
+    const r = await executeTool(makeTool('web_search', { query: 'calliope' }), tmpDir);
+    expect(r.result).toContain('Web search results for "calliope"');
+    expect(r.result).toContain('Title A');
+    expect(r.result).toContain('https://a.com');
+    expect(r.result).toContain('Snippet B');
+  });
+
+  it('honours num_results by limiting the number parsed', async () => {
+    httpsMock.body = DDG_HTML;
+    const r = await executeTool(makeTool('web_search', { query: 'calliope', num_results: 2 }), tmpDir);
+    expect(r.result).toContain('Title A');
+    expect(r.result).toContain('Title B');
+    expect(r.result).not.toContain('Title C');
+  });
+
+  it('reports when there are no results', async () => {
+    httpsMock.body = '<html><body>nothing here</body></html>';
+    const r = await executeTool(makeTool('web_search', { query: 'zxqw' }), tmpDir);
+    expect(r.result).toBe('No results found for: zxqw');
+  });
+
+  it('surfaces a request error', async () => {
+    httpsMock.mode = 'error';
+    httpsMock.errMsg = 'getaddrinfo ENOTFOUND';
+    const r = await executeTool(makeTool('web_search', { query: 'calliope' }), tmpDir);
+    expect(r.result).toContain('Search error: getaddrinfo ENOTFOUND');
+  });
+
+  it('surfaces a timeout', async () => {
+    httpsMock.mode = 'timeout';
+    const r = await executeTool(makeTool('web_search', { query: 'calliope' }), tmpDir);
+    expect(r.result).toBe('Search timed out');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// execute_code
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('execute_code', () => {
+  it('rejects an unsupported language', async () => {
+    const r = await executeTool(makeTool('execute_code', { language: 'ruby', code: 'puts 1' }), tmpDir);
+    expect(r.isError).toBe(true);
+    expect(r.result).toContain('language must be python, node, or bash');
+  });
+
+  it('rejects non-string code', async () => {
+    const r = await executeTool(makeTool('execute_code', { language: 'python', code: 42 }), tmpDir);
+    expect(r.isError).toBe(true);
+    expect(r.result).toContain('code must be a string');
+  });
+
+  it('formats native-sandbox success output', async () => {
+    sb.strategy = 'native';
+    sb.native = { stdout: 'hello', stderr: '', exitCode: 0, sandboxed: true, backend: 'seatbelt' };
+    const r = await executeTool(makeTool('execute_code', { language: 'python', code: 'print(1)' }), tmpDir);
+    expect(r.result).toContain('[sandboxed:seatbelt] ok [python]');
+    expect(r.result).toContain('Output:\nhello');
+  });
+
+  it('formats native-sandbox error output', async () => {
+    sb.strategy = 'native';
+    sb.native = { stdout: '', stderr: 'boom', exitCode: 1, sandboxed: true, backend: 'seatbelt' };
+    const r = await executeTool(makeTool('execute_code', { language: 'node', code: 'throw 1' }), tmpDir);
+    expect(r.result).toContain('[sandboxed:seatbelt] err [node]');
+    expect(r.result).toContain('Errors:\nboom');
+  });
+
+  it('reports an exit code when native output is empty', async () => {
+    sb.strategy = 'native';
+    sb.native = { stdout: '', stderr: '', exitCode: 3, sandboxed: false, backend: 'none' };
+    const r = await executeTool(makeTool('execute_code', { language: 'bash', code: 'exit 3' }), tmpDir);
+    expect(r.result).toContain('[unsandboxed] err [bash]');
+    expect(r.result).toContain('Exit code: 3');
+  });
+
+  it('formats unsandboxed output', async () => {
+    sb.strategy = 'unsandboxed';
+    sb.unsafe = { success: true, stdout: 'out', stderr: '', exitCode: 0, duration: 7 };
+    const r = await executeTool(makeTool('execute_code', { language: 'bash', code: 'echo out' }), tmpDir);
+    expect(r.result).toContain('[unsandboxed] ok [bash]');
+    expect(r.result).toContain('Output:\nout');
+    expect(r.result).toContain('Duration: 7ms');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// git security validation (short-circuits before any process spawns)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe('git validation', () => {
+  it('rejects a non-string operation', async () => {
+    const r = await executeTool(makeTool('git', { operation: 42 }), tmpDir);
+    expect(r.isError).toBe(true);
+    expect(r.result).toContain('operation must be a string');
+  });
+
+  it('rejects an unknown operation', async () => {
+    const r = await executeTool(makeTool('git', { operation: 'rebase' }), tmpDir);
+    expect(r.result).toContain('Unknown git operation: rebase');
+  });
+
+  it('blocks RCE-prone flags like --upload-pack', async () => {
+    const r = await executeTool(makeTool('git', { operation: 'push', args: '--upload-pack=evil origin' }), tmpDir);
+    expect(r.result).toContain('is not allowed (RCE risk)');
+  });
+
+  it('blocks the ext:: remote protocol', async () => {
+    const r = await executeTool(makeTool('git', { operation: 'pull', args: 'ext::sh -c evil' }), tmpDir);
+    expect(r.result).toContain('ext::');
+    expect(r.result).toContain('not allowed');
+  });
+
+  it('requires a -m message for commit', async () => {
+    const r = await executeTool(makeTool('git', { operation: 'commit', args: '' }), tmpDir);
+    expect(r.result).toBe('Error: commit requires -m "message"');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,13 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html', 'json-summary'],
       include: ['src/**/*.ts'],
+      // Thresholds only apply when coverage is collected (the `test:coverage`
+      // script, which passes --coverage). Plain `npm test` runs `vitest run`
+      // without --coverage, so it never evaluates these and stays gate-free
+      // for the per-PR CI check.
+      thresholds: {
+        lines: 90,
+      },
       exclude: [
         'src/bin.ts',
         // React/Ink UI — needs integration testing, not unit tests


### PR DESCRIPTION
## Summary
- Total line coverage 86.0% → 93.7% (+555 covered lines); statements 92.5%, functions 94.0%
- 136 new deterministic test cases across 6 new files + 1 extended: fleet relay internals (IRC state machine mocked at the net/tls seam with fake timers), fleet enabled-path, ollama, sandbox routing matrix, tools branches
- coverage.thresholds.lines: 90 in vitest.config.ts — npm run test:coverage now fails below the bar; plain npm test unaffected
- Pruning side of the issue was already done in lockstep with #176-181/#192-194 (114 → 94 test files, green at every merge)

## Test Plan
- npm test: 3,494 passed, 4 skipped, 0 failures (94 files)
- npm run test:coverage: 93.68% lines, exit 0; threshold enforcement proven by overriding to 99 (exits 1)

Fixes #182