### PR TITLE
Render scrollback via Ink Static; batch stream flushes at 30fps

### DIFF
--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -184,6 +184,84 @@ export class TokenBuffer {
 }
 
 // ============================================================================
+// Frame-bounded stream flusher
+// ============================================================================
+
+export interface StreamFlusher {
+  /** Buffer a token. The first token flushes synchronously (leading edge);
+   *  subsequent tokens are coalesced and flushed at most once per interval. */
+  push(token: string): void;
+  /** Flush any buffered tail immediately — call on stream completion so the
+   *  last tokens are never dropped. No-op when nothing is buffered. */
+  flush(): void;
+  /** Cancel: clear the pending timer and drop buffered tokens — call on
+   *  error/cancel paths so a queued flush can't fire after teardown. */
+  destroy(): void;
+}
+
+/**
+ * Coalesce streamed tokens so UI updates are frame-rate-bounded.
+ *
+ * Providers invoke `onToken` once per token; forwarding each straight to a React
+ * setState re-renders the transcript on every token — a full-frame redraw per
+ * token on a fast stream. This batches tokens and calls `onFlush` with the
+ * concatenated delta at most once per `intervalMs` (default 33ms ≈ 30fps). The
+ * first token flushes synchronously so perceived latency is unchanged.
+ *
+ * Distinct from {@link TokenBuffer}, which smooths on word/markdown boundaries
+ * for a typing effect and can withhold content mid-code-block: this is purely a
+ * time throttle and never holds tokens back on content boundaries.
+ */
+export function createStreamFlusher(
+  onFlush: (delta: string) => void,
+  intervalMs = 33,
+): StreamFlusher {
+  let pending = '';
+  let timer: NodeJS.Timeout | null = null;
+  let lastFlush = Number.NEGATIVE_INFINITY;
+
+  const emit = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (pending.length === 0) return;
+    const delta = pending;
+    pending = '';
+    lastFlush = Date.now();
+    onFlush(delta);
+  };
+
+  const schedule = (): void => {
+    if (timer) return; // a trailing flush is already queued
+    const wait = intervalMs - (Date.now() - lastFlush);
+    if (wait <= 0) {
+      emit(); // leading edge — enough time has passed, flush now
+    } else {
+      timer = setTimeout(emit, wait);
+    }
+  };
+
+  return {
+    push(token: string): void {
+      if (token.length === 0) return;
+      pending += token;
+      schedule();
+    },
+    flush(): void {
+      emit();
+    },
+    destroy(): void {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      pending = '';
+    },
+  };
+}
+
+// ============================================================================
 // Stream Transformers
 // ============================================================================
 

--- a/src/ui/agent.ts
+++ b/src/ui/agent.ts
@@ -21,6 +21,7 @@ import * as router from '../router.js';
 import { fleetActive, fleetMirrorAssistant } from '../fleet.js';
 import * as summarization from '../summarization.js';
 import { autoCompress } from '../auto-compressor.js';
+import { createStreamFlusher } from '../streaming.js';
 import { executeParallel, getParallelizationStats } from '../parallel-tools.js';
 import { checkAndWarnContextLimit } from './context.js';
 import { CircuitBreaker } from '../circuit-breaker.js';
@@ -277,6 +278,15 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
       }
     }
 
+    // Frame-bounded streaming: coalesce provider tokens so setStreamingResponse
+    // fires at most ~30fps instead of once per token (which re-rendered the
+    // transcript region on every token). The flusher is per-iteration; its
+    // pending timer is drained by flush() on success and cleared by destroy()
+    // on the error/cancel path below.
+    const streamFlusher = createStreamFlusher((delta) => {
+      ctx.setStreamingResponse(prev => prev + delta);
+    });
+
     try {
       // Update thinking state for LLM call
       ctx.setThinkingState({
@@ -291,10 +301,15 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
         startTime: Date.now(),
       });
 
-      // Streaming callback for final response
+      // Streaming callback for final response. Clear the thinking indicator on
+      // the first token, then hand the token to the frame-bounded flusher.
+      let streamStarted = false;
       const onToken = (token: string) => {
-        ctx.setThinkingState(null); // Clear thinking when streaming starts
-        ctx.setStreamingResponse(prev => prev + token);
+        if (!streamStarted) {
+          ctx.setThinkingState(null); // Clear thinking when streaming starts
+          streamStarted = true;
+        }
+        streamFlusher.push(token);
       };
 
       // Retry callback for error recovery
@@ -330,6 +345,7 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
       }
 
       const response = await chat(ctx.provider, validatedMessages, tools, effectiveModel, onToken, onRetry);
+      streamFlusher.flush(); // drain any batched tail before we swap to history
       ctx.debugLog('chat', 'GOT response', `toolCalls=${response.toolCalls?.length ?? 0}`);
 
       // Update token stats and cost
@@ -736,6 +752,7 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
       break;
 
     } catch (error) {
+      streamFlusher.destroy(); // stop any pending flush timer on error/cancel
       ctx.setThinkingState(null);
       ctx.setActivityState(null);
       ctx.setStreamingResponse('');

--- a/src/ui/messages.tsx
+++ b/src/ui/messages.tsx
@@ -1,8 +1,10 @@
 /**
  * UI Module - Message Components
  *
- * MessageItem and MessageHistory for displaying conversation messages.
- * All colors are sourced from the active palette via getInkColor().
+ * MessageItem renders a single conversation message; it is mapped over the
+ * transcript by StaticScrollback (regions/static-scrollback.tsx), which owns the
+ * write-once <Static> emission. All colors come from the active palette via
+ * getInkColor().
  */
 
 import React from 'react';
@@ -277,6 +279,12 @@ function MessageItemInner({ msg, collapse }: { msg: UIMessage; collapse?: Collap
 // renderMarkdown for already-finalized messages. A message's id/content are
 // immutable once committed, so the memo only re-renders when collapse settings
 // (which affect how the tool is displayed) actually change for this item.
+// Per-item memoization: appending a new message must not re-run renderMarkdown
+// for already-finalized messages. A message's id/content are immutable once
+// committed, so the memo only re-renders when this item's collapse settings
+// change. Under <StaticScrollback> this is a second line of defense — Static
+// already renders each item exactly once — but it keeps MessageItem correct in
+// isolation and for any future non-Static caller.
 export const MessageItem = React.memo(
   MessageItemInner,
   (prev, next) =>
@@ -287,33 +295,3 @@ export const MessageItem = React.memo(
     prev.collapse?.toolIndex === next.collapse?.toolIndex &&
     prev.collapse?.totalTools === next.collapse?.totalTools,
 );
-
-function MessageHistoryInner({ messages, collapseSettings }: { messages: UIMessage[]; collapseSettings: CollapseSettings }) {
-
-  // Count tool messages for toolDisplayLimit calculation
-  const toolMessages = messages.filter(m => m.type === 'tool');
-  const totalTools = toolMessages.length;
-
-  // Track tool index
-  let toolIndex = 0;
-
-  return (
-    <Box flexDirection="column">
-      {messages.map((msg) => {
-        const msgCollapseSettings = msg.type === 'tool'
-          ? { ...collapseSettings, toolIndex: toolIndex++, totalTools }
-          : collapseSettings;
-
-        return (
-          <Box key={msg.id}>
-            <MessageItem msg={msg} collapse={msgCollapseSettings} />
-          </Box>
-        );
-      })}
-    </Box>
-  );
-}
-
-// Memoized so unrelated parent re-renders (e.g. input keystrokes) don't
-// re-render the entire message list.
-export const MessageHistory = React.memo(MessageHistoryInner);

--- a/src/ui/regions/static-scrollback.tsx
+++ b/src/ui/regions/static-scrollback.tsx
@@ -1,0 +1,85 @@
+/**
+ * UI region - static scrollback
+ *
+ * Completed transcript entries rendered through Ink's <Static>. Static writes
+ * each item to stdout exactly once and never re-traverses it, so a growing
+ * scrollback and per-token streaming updates below no longer pay a full-frame
+ * redraw for history that hasn't changed.
+ *
+ * Two Static constraints shape this component:
+ *
+ *  1. APPEND-ONLY. Static tracks how many items it has emitted and only renders
+ *     the tail beyond that count. Items must therefore be appended, never
+ *     reordered or truncated. Every UIMessage is finalized before the next one
+ *     is appended (streaming text lives in the separate live zone, not here), so
+ *     `messages` is naturally append-only during a turn. Clearing/undo replace
+ *     the array non-append-only; the parent remounts this component (keyed on
+ *     clearCount) to reset Static's emitted-count rather than mutating it.
+ *
+ *  2. WRITE-ONCE COLLAPSE (tradeoff). A tool message's rendering depends on its
+ *     ordinal among tools (collapseTools/toolDisplayLimit windowing). Under
+ *     <Static> each item renders once, at append time, so that decision is
+ *     FROZEN then: a tool shown expanded when it was the newest stays expanded
+ *     even as newer tools arrive — the sliding collapse window no longer
+ *     re-collapses already-printed tools. This only affects sessions that opt
+ *     into collapseTools (default off; collapseThinking is currently always
+ *     off), where the default configuration is byte-identical to the previous
+ *     non-Static rendering. This is accepted, not worked around: a re-render
+ *     escape hatch would defeat the write-once guarantee that is the point.
+ */
+
+import React, { useEffect } from 'react';
+import { Box, Static } from 'ink';
+import type { UIMessage, CollapseSettings } from '../types.js';
+import { MessageItem } from '../messages.js';
+import { probeMount, probeRender } from './render-probe.js';
+
+export interface StaticScrollbackProps {
+  messages: UIMessage[];
+  collapseSettings: CollapseSettings;
+}
+
+function StaticScrollbackInner({ messages, collapseSettings }: StaticScrollbackProps) {
+  // Counts once per mount; the parent keys this component on clearCount, so a
+  // clear/reset remounts it and this fires again — the render-isolation proof
+  // that clearing actually resets Static's internal emitted-count.
+  useEffect(() => {
+    probeMount('transcript-static');
+  }, []);
+
+  // Per-item collapse context (ordinal among tools + tool count), matching the
+  // previous MessageHistory. Computed each render but consumed by Static only
+  // for newly-appended items, so a tool's context is captured at append time.
+  const totalTools = messages.reduce((n, m) => (m.type === 'tool' ? n + 1 : n), 0);
+  const toolOrdinal = new Map<string, number>();
+  let ordinal = 0;
+  for (const m of messages) {
+    if (m.type === 'tool') toolOrdinal.set(m.id, ordinal++);
+  }
+
+  return (
+    <Static items={messages}>
+      {(msg: UIMessage) => {
+        // Runs exactly once per message (Static only renders the unseen tail),
+        // so this count stays flat across streaming updates and rising only by
+        // one per appended message.
+        probeRender('transcript-item');
+        const collapse: CollapseSettings =
+          msg.type === 'tool'
+            ? { ...collapseSettings, toolIndex: toolOrdinal.get(msg.id), totalTools }
+            : collapseSettings;
+        return (
+          <Box key={msg.id}>
+            <MessageItem msg={msg} collapse={collapse} />
+          </Box>
+        );
+      }}
+    </Static>
+  );
+}
+
+// Memoized so a streaming/stats prop change on the parent transcript region
+// does not re-run Static's diff for unchanged history; only a new `messages`
+// reference (a message was appended) re-renders it. A clearCount change remounts
+// it via the `key` in the parent, independent of this comparison.
+export const StaticScrollback = React.memo(StaticScrollbackInner);

--- a/src/ui/regions/transcript-region.tsx
+++ b/src/ui/regions/transcript-region.tsx
@@ -1,20 +1,28 @@
 /**
  * UI region - transcript
  *
- * Message history + the processing/thinking/streaming indicators + the optional
- * debug overlay. Owns the state-transition tracking (derived purely from the
- * processing props) so that logic lives with the only region that renders it.
+ * Splits into two zones:
+ *  - STATIC ZONE: completed messages, rendered write-once via <StaticScrollback>
+ *    (Ink <Static>) so history is emitted to stdout once and never re-traversed
+ *    on streaming/stats updates or scrollback growth.
+ *  - LIVE ZONE: the processing/thinking/streaming indicators, the streaming
+ *    response block, the state transition, and the optional debug overlay — the
+ *    only things that change per token/tick.
+ *
+ * Owns the state-transition tracking (derived purely from the processing props)
+ * so that logic lives with the only region that renders it.
  *
  * Memoized: a keystroke never changes these props, so typing does not re-render
  * the transcript. Streaming/stats updates flow in as prop changes and re-render
- * only this region.
+ * this region's live zone only — the memoized StaticScrollback skips re-render
+ * because its `messages`/`collapseSettings` props are unchanged.
  */
 
 import React, { useState, useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import type { UIMessage, CollapseSettings, ThinkingState, ActivityState } from '../types.js';
 import type { Mode } from '../../types.js';
-import { MessageHistory } from '../messages.js';
+import { StaticScrollback } from './static-scrollback.js';
 import { ThinkingDisplay, ProcessingIndicator, StreamingIndicator, StateTransition } from '../components.js';
 import { probeRender } from './render-probe.js';
 
@@ -23,6 +31,10 @@ type ProcPhase = 'idle' | 'thinking' | 'streaming' | 'done';
 export interface TranscriptRegionProps {
   messages: UIMessage[];
   collapseSettings: CollapseSettings;
+  /** Monotonic counter bumped when `messages` is cleared/replaced non-append.
+   *  Used as the StaticScrollback `key` so Static remounts (fresh emitted-count)
+   *  instead of desyncing against a truncated list. */
+  clearCount: number;
   isProcessing: boolean;
   thinkingState: ThinkingState | null;
   streamingResponse: string;
@@ -35,6 +47,7 @@ export interface TranscriptRegionProps {
 function TranscriptRegionInner({
   messages,
   collapseSettings,
+  clearCount,
   isProcessing,
   thinkingState,
   streamingResponse,
@@ -95,8 +108,9 @@ function TranscriptRegionInner({
 
   return (
     <>
-      {/* Chat history, processing indicator, then the streaming response. */}
-      <MessageHistory messages={messages} collapseSettings={collapseSettings} />
+      {/* Completed history (write-once), then the live processing indicator and
+          streaming response. `key={clearCount}` remounts Static on clear/reset. */}
+      <StaticScrollback key={clearCount} messages={messages} collapseSettings={collapseSettings} />
       {ProcessingBox}
       {StreamingResponseBox}
 

--- a/src/ui/state/use-chat-controller.ts
+++ b/src/ui/state/use-chat-controller.ts
@@ -91,7 +91,7 @@ export function useChatController(): ChatController {
   const queue = useQueueState();
   const loop = useLoopState();
 
-  const { messages, collapseSettings, addMessage, setMessages } = transcript;
+  const { messages, collapseSettings, clearCount, addMessage, setMessages } = transcript;
   const { isProcessing, thinkingState, streamingResponse, activityState,
     setIsProcessing, setThinkingState, setStreamingResponse, setActivityState } = proc;
   const { provider, model, mode, confirmMode, autoRoute, smartRouteActive, breakerHealth,
@@ -645,7 +645,7 @@ export function useChatController(): ChatController {
   // stable useCallback refs when unchanged. This also keeps module-level reads
   // (debugEnabled) fresh on every render, matching the original.
   const transcriptProps: TranscriptRegionProps = {
-    messages, collapseSettings, isProcessing, thinkingState, streamingResponse, activityState,
+    messages, collapseSettings, clearCount, isProcessing, thinkingState, streamingResponse, activityState,
     debugEnabled: isDebugEnabled(), mode, queuedCount: queuedMessages.length,
   };
 

--- a/src/ui/state/use-transcript-state.ts
+++ b/src/ui/state/use-transcript-state.ts
@@ -6,7 +6,7 @@
  * mutated in-session, matching the original behavior.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import * as config from '../../config.js';
 import * as storage from '../../storage.js';
 import type { UIMessage, CollapseSettings } from '../types.js';
@@ -15,17 +15,35 @@ export interface TranscriptStateHook {
   messages: UIMessage[];
   setMessages: React.Dispatch<React.SetStateAction<UIMessage[]>>;
   collapseSettings: CollapseSettings;
+  /** Monotonic counter, bumped whenever the message list shrinks (clear/undo/
+   *  reset). The transcript region uses it to key <Static>, forcing a remount
+   *  so Static's write-once emitted-count is reset when history is dropped. */
+  clearCount: number;
   addMessage: (type: UIMessage['type'], content: string, isError?: boolean) => void;
   reset: () => void;
 }
 
 export function useTranscriptState(): TranscriptStateHook {
   const [messages, setMessages] = useState<UIMessage[]>([]);
+  const [clearCount, setClearCount] = useState(0);
+  const prevLen = useRef(0);
   const [collapseSettings] = useState<CollapseSettings>(() => ({
     collapseTools: config.get('collapseTools') ?? false,
     collapseThinking: false,
     toolDisplayLimit: config.get('toolDisplayLimit') ?? 0,
   }));
+
+  // <Static> assumes append-only items. Every non-append mutation in this app
+  // shrinks the list: /clear and reset() empty it, /undo restores a shorter
+  // prefix. Detect the shrink here (a single source of truth co-located with
+  // the state) and bump clearCount so the transcript region remounts Static.
+  // Pure appends only grow the list, so they never bump.
+  useEffect(() => {
+    if (messages.length < prevLen.current) {
+      setClearCount(c => c + 1);
+    }
+    prevLen.current = messages.length;
+  }, [messages]);
 
   const addMessage = useCallback((type: UIMessage['type'], content: string, isError?: boolean) => {
     setMessages(prev => [...prev, {
@@ -45,5 +63,5 @@ export function useTranscriptState(): TranscriptStateHook {
 
   const reset = useCallback(() => setMessages([]), []);
 
-  return { messages, setMessages, collapseSettings, addMessage, reset };
+  return { messages, setMessages, collapseSettings, clearCount, addMessage, reset };
 }

--- a/tests/ui-static-scrollback.test.ts
+++ b/tests/ui-static-scrollback.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Static scrollback + frame-bounded streaming tests (#185).
+ *
+ * Proves the two performance mechanisms added in #185:
+ *
+ *  1. STATIC SCROLLBACK — completed messages render through Ink's <Static>, so
+ *     each is emitted once and never re-traversed when a new message appends or
+ *     the streaming block below updates. A clearCount bump remounts <Static> so
+ *     clearing/reset resets its write-once emitted-count.
+ *
+ *  2. FRAME-BOUNDED STREAMING — createStreamFlusher coalesces provider tokens so
+ *     the UI setter fires at ~30fps (immediate first flush, batched rest, final
+ *     flush drains the tail) instead of once per token.
+ *
+ * Note on <Static> + ink-testing-library: Ink runs in debug mode there, which
+ * ACCUMULATES all static output and re-emits it as a prefix on every frame (it
+ * mirrors a real terminal's un-eraseable scrollback). So "static not re-emitted"
+ * cannot be shown by counting a message across frames — every frame after it was
+ * printed contains it. The write-once property is instead proven via the render
+ * probe: Static invokes the item render fn exactly once per message, regardless
+ * of how many times the parent region re-renders.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { render } from 'ink-testing-library';
+
+// ---------------------------------------------------------------------------
+// Mocks — config feeds hud/api + collapse defaults; storage backs addMessage.
+// ---------------------------------------------------------------------------
+
+vi.mock('../src/config.js', () => {
+  const get = vi.fn((key: string) => {
+    switch (key) {
+      case 'collapseTools': return false;
+      case 'toolDisplayLimit': return 0;
+      default: return undefined;
+    }
+  });
+  const api = { get, set: vi.fn(), getApiKey: vi.fn(() => undefined), getBaseUrl: vi.fn(() => undefined) };
+  return { default: api, ...api };
+});
+
+vi.mock('../src/storage.js', () => ({
+  addChatMessage: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports AFTER mocks.
+// ---------------------------------------------------------------------------
+
+import { TranscriptRegion } from '../src/ui/regions/transcript-region.js';
+import type { TranscriptRegionProps } from '../src/ui/regions/transcript-region.js';
+import { useTranscriptState } from '../src/ui/state/use-transcript-state.js';
+import type { TranscriptStateHook } from '../src/ui/state/use-transcript-state.js';
+import { createStreamFlusher } from '../src/streaming.js';
+import {
+  enableRenderProbe, getRenderCount, getMountCount,
+} from '../src/ui/regions/render-probe.js';
+import type { UIMessage, CollapseSettings } from '../src/ui/types.js';
+import type { Mode } from '../src/types.js';
+
+const h = React.createElement;
+const tick = () => new Promise(resolve => setTimeout(resolve, 25));
+
+const COLLAPSE: CollapseSettings = { collapseTools: false, collapseThinking: false, toolDisplayLimit: 0 };
+const sys = (id: string, content: string): UIMessage => ({ id, type: 'system', content });
+
+/** Build TranscriptRegion props with stable defaults so only the fields under
+ *  test change identity between rerenders. */
+function tp(over: Partial<TranscriptRegionProps>): TranscriptRegionProps {
+  return {
+    messages: [],
+    collapseSettings: COLLAPSE,
+    clearCount: 0,
+    isProcessing: false,
+    thinkingState: null,
+    streamingResponse: '',
+    activityState: null,
+    debugEnabled: false,
+    mode: 'work' as Mode,
+    queuedCount: 0,
+    ...over,
+  };
+}
+
+// ===========================================================================
+// 1. Static scrollback rendering
+// ===========================================================================
+
+describe('StaticScrollback rendering (#185)', () => {
+  beforeEach(() => { enableRenderProbe(true); });
+  afterEach(() => { enableRenderProbe(false); });
+
+  it('emits each completed message once and never re-emits on streaming updates or appends', async () => {
+    const msgs = [sys('a', 'ALPHA1'), sys('b', 'BRAVO2'), sys('c', 'CHARLIE3')];
+    const { rerender, lastFrame, unmount } = render(h(TranscriptRegion, tp({ messages: msgs })));
+    await tick();
+
+    // Static rendered each of the three items exactly once.
+    expect(getRenderCount('transcript-item')).toBe(3);
+    expect(lastFrame()).toContain('ALPHA1');
+    expect(lastFrame()).toContain('CHARLIE3');
+
+    // Streaming updates: change only streamingResponse, keep the same messages
+    // reference. Five re-renders of the transcript region.
+    for (const s of ['H', 'He', 'Hel', 'Hell', 'Hello']) {
+      rerender(h(TranscriptRegion, tp({ messages: msgs, streamingResponse: s })));
+      await tick();
+    }
+
+    // No completed item was re-emitted despite the streaming churn.
+    expect(getRenderCount('transcript-item')).toBe(3);
+    // The live zone shows the streaming text; history is untouched.
+    expect(lastFrame()).toContain('Hello');
+    // Each completed message still appears exactly once in the current frame.
+    expect((lastFrame()!.match(/ALPHA1/g) || []).length).toBe(1);
+
+    // Appending a fourth message emits ONLY the new item.
+    const grown = [...msgs, sys('d', 'DELTA4')];
+    rerender(h(TranscriptRegion, tp({ messages: grown, streamingResponse: 'Hello' })));
+    await tick();
+    expect(getRenderCount('transcript-item')).toBe(4);
+    expect(lastFrame()).toContain('DELTA4');
+
+    unmount();
+  });
+
+  it('remounts Static on a clearCount bump so post-clear messages render', async () => {
+    const { rerender, lastFrame, unmount } = render(
+      h(TranscriptRegion, tp({ messages: [sys('a', 'KEEP1')], clearCount: 0 })),
+    );
+    await tick();
+    expect(getMountCount('transcript-static')).toBe(1);
+    expect(lastFrame()).toContain('KEEP1');
+
+    // Clear: empty list + clearCount bump (exactly what the transcript state does).
+    rerender(h(TranscriptRegion, tp({ messages: [], clearCount: 1 })));
+    await tick();
+    // The clearCount key change remounted Static (fresh write-once emitted-count).
+    expect(getMountCount('transcript-static')).toBe(2);
+
+    // A message appended after the clear still renders — Static is not stuck.
+    rerender(h(TranscriptRegion, tp({ messages: [sys('b', 'FRESH2')], clearCount: 1 })));
+    await tick();
+    expect(lastFrame()).toContain('FRESH2');
+    // Same clearCount => no additional remount from the append.
+    expect(getMountCount('transcript-static')).toBe(2);
+
+    unmount();
+  });
+});
+
+// ===========================================================================
+// 2. clearCount wiring in the transcript state
+// ===========================================================================
+
+describe('useTranscriptState clearCount (#185)', () => {
+  function Harness({ apiRef }: { apiRef: { current: TranscriptStateHook | null } }) {
+    const state = useTranscriptState();
+    apiRef.current = state;
+    return h(React.Fragment, null);
+  }
+
+  it('bumps clearCount when the list shrinks (clear/reset/undo), never on append', async () => {
+    const apiRef: { current: TranscriptStateHook | null } = { current: null };
+    const { unmount } = render(h(Harness, { apiRef }));
+    await tick();
+    expect(apiRef.current!.clearCount).toBe(0);
+
+    // Two appends — the list only grows, so clearCount stays put.
+    apiRef.current!.addMessage('user', 'one');
+    await tick();
+    apiRef.current!.addMessage('assistant', 'two');
+    await tick();
+    expect(apiRef.current!.messages.length).toBe(2);
+    expect(apiRef.current!.clearCount).toBe(0);
+
+    // reset() empties the list — a shrink — which bumps clearCount once.
+    apiRef.current!.reset();
+    await tick();
+    expect(apiRef.current!.messages.length).toBe(0);
+    expect(apiRef.current!.clearCount).toBe(1);
+
+    // Undo-style shrink: grow, then restore a shorter prefix, bumps again.
+    apiRef.current!.addMessage('user', 'a');
+    await tick();
+    apiRef.current!.addMessage('user', 'b');
+    await tick();
+    expect(apiRef.current!.clearCount).toBe(1); // appends did not bump
+    apiRef.current!.setMessages(prev => prev.slice(0, 1));
+    await tick();
+    expect(apiRef.current!.messages.length).toBe(1);
+    expect(apiRef.current!.clearCount).toBe(2);
+
+    unmount();
+  });
+});
+
+// ===========================================================================
+// 3. Frame-bounded streaming flusher
+// ===========================================================================
+
+describe('createStreamFlusher (#185)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('flushes the first token immediately then batches the rest to <=30fps', () => {
+    const onFlush = vi.fn();
+    const flusher = createStreamFlusher(onFlush, 33);
+
+    // First token flushes synchronously (leading edge, perceived latency).
+    flusher.push('t0 ');
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenLastCalledWith('t0 ');
+
+    // 99 more tokens within the same frame window — all coalesced, no new flush.
+    for (let i = 1; i < 100; i++) flusher.push(`t${i} `);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    // Completion drains the batched tail.
+    flusher.flush();
+    expect(onFlush).toHaveBeenCalledTimes(2);
+
+    // Far fewer than 100 calls, yet every token was delivered exactly once.
+    expect(onFlush.mock.calls.length).toBeLessThanOrEqual(4);
+    const delivered = onFlush.mock.calls.map(c => c[0]).join('');
+    const expected = Array.from({ length: 100 }, (_, i) => `t${i} `).join('');
+    expect(delivered).toBe(expected);
+  });
+
+  it('fires a trailing flush after the interval elapses', () => {
+    const onFlush = vi.fn();
+    const flusher = createStreamFlusher(onFlush, 33);
+
+    flusher.push('lead');       // leading flush
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    flusher.push('tail');       // buffered; trailing flush scheduled
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(33); // trailing flush fires
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush).toHaveBeenLastCalledWith('tail');
+
+    // Nothing pending — advancing further does not flush again.
+    vi.advanceTimersByTime(1000);
+    expect(onFlush).toHaveBeenCalledTimes(2);
+  });
+
+  it('destroy() drops buffered tokens and cancels the pending timer', () => {
+    const onFlush = vi.fn();
+    const flusher = createStreamFlusher(onFlush, 33);
+
+    flusher.push('lead');   // leading flush
+    flusher.push('dropped'); // buffered + timer scheduled
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    flusher.destroy();
+    vi.advanceTimersByTime(1000);
+    // The scheduled flush never fires and the tail is dropped.
+    expect(onFlush).toHaveBeenCalledTimes(1);
+
+    // A post-destroy flush is a no-op (buffer already cleared).
+    flusher.flush();
+    expect(onFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('flush() with an empty buffer does not call the sink', () => {
+    const onFlush = vi.fn();
+    const flusher = createStreamFlusher(onFlush, 33);
+    flusher.flush();
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Completed messages render inside <Static> keyed by msg.id — written to stdout once, never re-traversed; render-probe tests prove item render counts stay flat across streaming updates
- Live zone (thinking/processing/streaming/transition/debug) is the only dynamic part of the transcript
- Clear/reset/undo remount the Static zone via a shrink-detection clearCount — covers /clear, resetSession, and /undo without threading calls through commands.ts
- New StreamFlusher (leading-edge throttle): first token paints immediately, then ≤1 UI update per 33ms, tail guaranteed, destroyed on cancel/error. TokenBuffer was the wrong tool — its markdown smoothing withholds content mid-code-block
- Documented tradeoff: Static items are write-once, so retroactive re-collapse of already-printed tool output no longer happens (default config renders byte-identically)

## Test Plan
- npm run build clean; npm test: 3,504 passed, 4 skipped (96 files)
- New tests/ui-static-scrollback.test.ts (7 tests, stable across 3 runs); render-isolation suite unchanged and green
- Terminal flicker verification (iTerm2/Terminal/tmux) goes on Leo's live-testing checklist — frames can't be asserted from CI

Fixes #185