### PR TITLE
Add local-model excellence: compensation, anchored edits, compact prompts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ provider backends, and a small, tested command surface.
 - [Commands](./commands.md) — all 22 commands and their subcommands
 - [Configuration](./configuration.md) — config keys, defaults, environment variables
 - [Providers](./providers.md) — supported backends and how credentials resolve
+- [Local models](./local-models.md) — how the harness adapts to self-hosted 7-70B models
 - [Features](./features.md) — the full v3 feature set (and what was removed)
 - [Fleet mode](./fleet.md) — optional multi-agent coordination over IRC
 

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -1,0 +1,149 @@
+# Local models
+
+Calliope aims to be the best terminal harness for **self-hosted 7-70B models** —
+the ones you run yourself with Ollama, vLLM, LM Studio, llama.cpp, or a local
+LiteLLM proxy. Small and mid-size open-weight models are more sensitive than
+frontier cloud models to prompt bloat, verbose tool schemas, and the occasional
+malformed tool call. Calliope detects a local backend and quietly adapts.
+
+None of this changes cloud behaviour: every adaptation below is gated on backend
+detection and is a no-op for Anthropic, OpenAI, Google, Bedrock, and hosted
+OpenAI-compatible providers.
+
+## What "local" means here
+
+A backend is treated as local when:
+
+- the provider is **`ollama`** (always local), or
+- the provider is **`litellm`** or **`openai-compat`** and its base URL is a
+  loopback host — `localhost`, `127.0.0.1`, `0.0.0.0`, `::1`,
+  `host.docker.internal`, or a `*.local` hostname (e.g. a box running vLLM).
+
+Hosted proxies (a `litellm` pointed at a remote URL, OpenRouter, Together, …)
+are treated as cloud.
+
+## What the harness does for local models
+
+### 1. Simplified tool schemas
+
+The full tool schemas Calliope sends to a model are verbose — long descriptions,
+multi-paragraph help, big enum listings. For a local model that all competes with
+the actual task for context. When the backend is local, Calliope sends a
+**simplified** schema:
+
+- tool and parameter descriptions trimmed to their first sentence,
+- enum listings capped,
+- (for `edit_file`) an extra optional `anchor_hash` parameter (see below).
+
+This is **lossless for execution**: the real argument validation runs
+server-side in the tool layer, so trimming what the model is *shown* can never
+break a valid call.
+
+### 2. One-shot malformed-tool-call repair
+
+Small models occasionally emit a tool call that is almost-but-not-quite right: a
+misspelled tool name, or a call missing a required parameter (this is also how an
+unparseable arguments blob presents — it arrives as `{}`). Instead of surfacing
+the error immediately, Calliope spends **one** corrective round-trip:
+
+> Your tool call to "reae_file" was malformed: unknown tool "reae_file"; did you
+> mean "read_file"?. Reply with ONLY the corrected tool call, nothing else.
+
+If the model returns a valid call, it executes normally. If the repair is still
+malformed, the error surfaces as usual — there is no second repair for the same
+call. Each repair is recorded in the iteration ledger.
+
+### 3. Grammar-constrained repair (Ollama)
+
+On the repair round-trip only, and only when the backend is Ollama, Calliope
+passes Ollama's `format` parameter — a JSON schema of the tool-call envelope
+(`{ name, arguments }`) — to *force* a well-formed reply. Constraining every
+turn would break prose, so this applies to the repair turn alone. If the Ollama
+build rejects the schema, Calliope silently retries the request without it.
+
+### 4. Hash-anchored edits (stale-view protection)
+
+Long agent loops can drift: a model edits a file based on a copy it read many
+turns ago, after the file has changed. For local backends, `read_file` output
+ends with a short content hash:
+
+```
+[anchor_hash: 1a2b3c4d — pass as anchor_hash to edit_file to confirm this view is current]
+```
+
+The model can echo that value back as `edit_file`'s optional `anchor_hash`
+argument. If it no longer matches the file's current content, the edit is
+rejected with a message telling the model to re-read the file first. The
+parameter is optional and inert when omitted, so cloud edits are unaffected.
+
+### 5. Compact system prompt
+
+Local backends receive a compact system prompt: the non-negotiable `[SAFETY]`
+rules block is kept **verbatim**, while the verbose grounding section and long
+base prompt collapse to one tight paragraph. The compact prompt is under 40% of
+the full prompt's tokens. Cloud providers keep the full prompt.
+
+### 6. Capability detection
+
+Calliope probes a local model's capabilities once per session
+(`getLocalModelProfile`):
+
+- **context length** — from Ollama's `/api/show` (`model_info`, or a `num_ctx`
+  Modelfile override), else a family default;
+- **native tool calls** — from Ollama's `capabilities` list when present
+  (`"tools"`), else a heuristic by model family;
+- **JSON-schema `format` support** — true for native Ollama, false elsewhere.
+
+The circuit breaker also relaxes its cost/token limits for `ollama` and
+`litellm`, since self-hosted inference is effectively free.
+
+## Configuration
+
+Point Calliope at a local backend during `calliope --setup`, or directly:
+
+```bash
+# Ollama (native /api/chat — best tool-calling support)
+export OLLAMA_BASE_URL=http://localhost:11434
+calliope --provider ollama --model gemma4:31b
+
+# Any OpenAI-compatible local server (vLLM, LM Studio, llama.cpp, …)
+export OPENAI_COMPAT_BASE_URL=http://localhost:8000
+calliope --provider openai-compat
+
+# Local LiteLLM proxy
+export LITELLM_BASE_URL=http://localhost:4000
+calliope --provider litellm
+```
+
+Notes:
+
+- The compact prompt and schema simplification apply automatically once the
+  provider is a local backend. If you run `defaultProvider: auto` with *only* a
+  local backend configured, set the provider explicitly (`--provider ollama`) to
+  get the compact prompt from the first turn.
+- `OPENAI_COMPAT_SHIM` still applies for quirky local servers (LM Studio,
+  AnythingLLM, vLLM, Jan, LocalAI) — see [Providers](./providers.md).
+
+## Observed behaviour: `gemma4:31b` on Ollama
+
+Measured live against a local Ollama (`ollama` provider, native `/api/chat`):
+
+| Probe | Result |
+|-------|--------|
+| `/api/show` capabilities | `["completion", "vision", "tools", "thinking"]` |
+| Reported context length | 262144 (256K) |
+| Chat round-trip | Works; clean `finishReason: stop`, token usage reported. |
+| **Native tool calls** | **Yes** — returns a structured `tool_calls` entry (`finishReason: tool_use`) with correct arguments, empty text content. No XML/text fallback needed. |
+| `format` param (JSON schema) | **Accepted** (HTTP 200). Produces exactly the constrained envelope, e.g. `{"name":"read_file","arguments":{"path":"./README.md"}}`. |
+| Repair round-trip | With a typo'd tool name + corrective message + `format`, the model returned a corrected **native** tool call (`read_file` with the right args); Calliope extracted it and confirmed it was no longer malformed. |
+
+Takeaways: gemma4:31b is a strong local harness target — it does reliable native
+tool calls through Ollama, honours the `format` grammar constraint, and responds
+well to the one-shot repair. When both `tools` and `format` are supplied on the
+repair turn it prefers native `tool_calls`; Calliope's extractor handles both the
+native path and the JSON envelope.
+
+Other families are handled by the same code paths. Models whose `/api/show`
+capabilities omit `"tools"` (e.g. a vision-only model) fall back to text-based
+tool-call parsing; models Ollama doesn't report capabilities for fall back to a
+family heuristic (llama 3.1+, qwen 2.5+, mistral, devstral, command-r, …).

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -9,7 +9,8 @@
 import * as config from './config.js';
 import { chat, selectProvider } from './providers/index.js';
 import { TOOLS, executeTool, getTools } from './tools.js';
-import { getSystemPrompt, DEFAULT_MODELS } from './types.js';
+import { DEFAULT_MODELS } from './types.js';
+import { getSystemPromptForProvider, isLocalBackend } from './local-model.js';
 import * as memory from './memory.js';
 import { resolveIterationLimit } from './iteration-limit.js';
 import type { Message, LLMProvider, ToolCall } from './types.js';
@@ -160,8 +161,19 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
     return 1;
   }
 
+  // Resolve the provider so 'auto' picks up a local backend correctly, then
+  // select the compact-vs-full system prompt for it (feature 5). Falls back to
+  // the raw provider if selection would throw (chat() surfaces the real error).
+  let resolvedProvider: LLMProvider;
+  try {
+    resolvedProvider = selectProvider(provider);
+  } catch {
+    resolvedProvider = provider;
+  }
+  const localBackend = isLocalBackend(resolvedProvider);
+
   // Build messages
-  const systemPrompt = getSystemPrompt();
+  const systemPrompt = getSystemPromptForProvider(resolvedProvider);
   const memoryContext = memory.buildMemoryContext(cwd);
   const fullPrompt = memoryContext.trim()
     ? systemPrompt + '\n\n--- Project Context ---\n' + memoryContext
@@ -213,7 +225,7 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
           // Execute tool with a guarded retry budget.
           // Only retry classified-transient errors, never re-run mutating tools
           // (avoids duplicated side effects), and back off between attempts.
-          let result = await executeTool(toolCall, cwd);
+          let result = await executeTool(toolCall, cwd, 60000, undefined, { appendAnchorHash: localBackend });
           let attempt = 0;
           while (
             result.isError &&
@@ -223,7 +235,7 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
             attempt++;
             await sleep(backoffDelay(attempt));
             process.stderr.write(`[retry ${attempt}/${maxRetries}] tool failed: ${result.result}\n`);
-            result = await executeTool(toolCall, cwd);
+            result = await executeTool(toolCall, cwd, 60000, undefined, { appendAnchorHash: localBackend });
           }
 
 

--- a/src/local-model.ts
+++ b/src/local-model.ts
@@ -1,0 +1,458 @@
+/**
+ * Calliope CLI - Local Model Excellence
+ *
+ * A single home for the behaviours that make Calliope a good harness for
+ * self-hosted 7-70B models (Ollama, or an OpenAI-compatible/LiteLLM server
+ * pointed at localhost / a private box running vLLM etc.). Cloud providers are
+ * untouched — every helper here is a no-op or "cloud" answer unless the active
+ * backend is detected as local.
+ *
+ * Responsibilities:
+ *  - Detect whether a provider/baseUrl pair is a local backend.
+ *  - Simplify tool JSON-schemas before they are sent to a local model (lossless
+ *    for execution — tools.ts still validates the real args).
+ *  - Compute and verify content anchor hashes for stale-view-protected edits.
+ *  - Detect malformed tool calls and describe how to repair them.
+ *  - Build the JSON-schema envelope used to grammar-constrain a repair reply.
+ *  - Probe a local model's capabilities (context length, native tool calls,
+ *    JSON-schema `format` support) and cache the result per session.
+ *  - Pick the compact vs full system prompt for a provider.
+ */
+
+import { createHash } from 'node:crypto';
+import * as config from './config.js';
+import type { LLMProvider, Tool, ToolCall } from './types.js';
+import { getSystemPrompt } from './types.js';
+import { getModelContextLimit } from './model-detection.js';
+
+// ============================================================================
+// Backend detection
+// ============================================================================
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]', 'host.docker.internal']);
+
+/**
+ * True when a URL points at the local machine (loopback host, `*.local`, or the
+ * docker host bridge). Used to decide whether an openai-compat / LiteLLM server
+ * is a self-hosted backend rather than a hosted proxy.
+ */
+export function isLoopbackUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    // Not a parseable URL — fall back to a substring check on the raw value.
+    const lower = url.toLowerCase();
+    return [...LOOPBACK_HOSTS].some(h => lower.includes(h)) || lower.includes('.local');
+  }
+  if (LOOPBACK_HOSTS.has(host)) return true;
+  if (host.endsWith('.local')) return true;
+  return false;
+}
+
+/**
+ * Whether the active backend is a locally-hosted model.
+ *
+ *  - `ollama` is always local.
+ *  - `openai-compat` / `litellm` are local when their base URL is loopback
+ *    (LM Studio, vLLM, llama.cpp, a local LiteLLM proxy, ...).
+ *  - Everything else (Anthropic, OpenAI, Bedrock, hosted OpenAI-compat, and the
+ *    `auto` sentinel) is treated as cloud.
+ *
+ * `baseUrl` defaults to the configured base URL for the provider.
+ */
+export function isLocalBackend(provider: LLMProvider, baseUrl?: string): boolean {
+  if (provider === 'ollama') return true;
+  if (provider === 'litellm' || provider === 'openai-compat') {
+    const url = baseUrl ?? config.getBaseUrl(provider);
+    return isLoopbackUrl(url);
+  }
+  return false;
+}
+
+// ============================================================================
+// Schema simplification (feature 1)
+// ============================================================================
+
+/** Maximum enum values kept in a simplified schema (execution still accepts any). */
+const ENUM_CAP = 12;
+/** Maximum characters kept for a tool description in a simplified schema. */
+const TOOL_DESC_CAP = 200;
+/** Maximum characters kept for a property description in a simplified schema. */
+const PROP_DESC_CAP = 80;
+
+/**
+ * The `anchor_hash` property injected into `edit_file`'s SIMPLIFIED schema only
+ * (feature 4). tools.ts accepts it from any caller, but it is only advertised to
+ * local models — cloud schemas stay inert.
+ */
+export const ANCHOR_HASH_PROPERTY = {
+  type: 'string',
+  description: 'Optional 8-char hash from the last read_file of this file (stale-edit guard); echo it to confirm your view is current.',
+} as const;
+
+/** The property key models echo back on an anchored edit. */
+export const ANCHOR_HASH_KEY = 'anchor_hash';
+
+/**
+ * Reduce a verbose description to its first sentence, single-line and capped.
+ * Multi-paragraph tool descriptions (e.g. `configure`) collapse to their lede.
+ */
+export function firstSentence(text: string | undefined, cap: number): string {
+  if (!text) return text ?? '';
+  let s = text.trim();
+  // Drop everything after the first newline — verbose schemas put reference
+  // material on subsequent lines.
+  const nl = s.search(/\r?\n/);
+  if (nl !== -1) s = s.slice(0, nl).trim();
+  // Keep only the first sentence within that line.
+  const m = s.match(/^.*?[.!?](?=\s|$)/);
+  if (m) s = m[0].trim();
+  if (s.length > cap) s = s.slice(0, cap - 1).trimEnd() + '…';
+  return s;
+}
+
+interface SchemaProperty {
+  type: string;
+  description?: string;
+  enum?: string[];
+  items?: { type: string };
+}
+
+function simplifyProperty(prop: SchemaProperty): SchemaProperty {
+  const out: SchemaProperty = { type: prop.type };
+  if (prop.description) out.description = firstSentence(prop.description, PROP_DESC_CAP);
+  if (prop.enum) out.enum = prop.enum.length > ENUM_CAP ? prop.enum.slice(0, ENUM_CAP) : prop.enum;
+  if (prop.items) out.items = prop.items;
+  return out;
+}
+
+/**
+ * Simplify a tool schema for a local model: first-sentence descriptions, capped
+ * enum listings, and (for `edit_file`) the optional `anchor_hash` param.
+ *
+ * LOSSLESS FOR EXECUTION: the returned schema only changes what the model is
+ * shown. tools.ts validates the real arguments independently, so trimming a
+ * description or truncating an enum listing cannot break a valid call.
+ *
+ * Calliope's tool schemas are already flat (no nested object properties), so the
+ * "flatten nested objects" goal is a structural no-op here; the real token win
+ * is in the descriptions and enums.
+ */
+export function simplifyToolForLocal(tool: Tool): Tool {
+  const properties: Record<string, SchemaProperty> = {};
+  for (const [key, prop] of Object.entries(tool.parameters.properties)) {
+    properties[key] = simplifyProperty(prop as SchemaProperty);
+  }
+  // Advertise the stale-view guard to local models on edit_file only.
+  if (tool.name === 'edit_file') {
+    properties[ANCHOR_HASH_KEY] = { ...ANCHOR_HASH_PROPERTY };
+  }
+  return {
+    name: tool.name,
+    description: firstSentence(tool.description, TOOL_DESC_CAP),
+    parameters: {
+      type: 'object',
+      properties: properties as Tool['parameters']['properties'],
+      ...(tool.parameters.required ? { required: tool.parameters.required } : {}),
+    },
+  };
+}
+
+/** Simplify a whole tool set for a local backend. Empty in → empty out. */
+export function simplifyToolsForLocal(tools: Tool[]): Tool[] {
+  return tools.map(simplifyToolForLocal);
+}
+
+// ============================================================================
+// Anchor hashes (feature 4)
+// ============================================================================
+
+/** 8-char sha256 prefix of file content — the stable "view id" a model echoes. */
+export function computeAnchorHash(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex').slice(0, 8);
+}
+
+/** Footer appended to read_file output for local backends so the model can echo the hash. */
+export function anchorHashFooter(hash: string): string {
+  return `\n[anchor_hash: ${hash} — pass as anchor_hash to edit_file to confirm this view is current]`;
+}
+
+// ============================================================================
+// Malformed tool-call detection + repair (features 2 & 3)
+// ============================================================================
+
+/** Classic Levenshtein edit distance (iterative, two-row). */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  let curr = new Array<number>(b.length + 1);
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length];
+}
+
+/** Max edit distance for an unknown tool name to count as a repairable typo. */
+const NAME_MATCH_THRESHOLD = 2;
+
+export interface MalformedToolCall {
+  /** Human-readable reason, embedded verbatim in the corrective message. */
+  reason: string;
+  /** Suggested correct tool name, when the fault is a close-miss name. */
+  suggestion?: string;
+}
+
+/**
+ * Detect whether a parsed tool call is malformed in a way worth one repair
+ * round-trip. Returns null for a well-formed call OR for an unknown tool with no
+ * close match (there is nothing to correct — let it surface naturally).
+ *
+ *  - unknown tool name with a close Levenshtein match → suggest the neighbour
+ *  - missing a required parameter (also how unparseable-args `{}` presents)
+ */
+export function detectMalformedToolCall(call: ToolCall, tools: Tool[]): MalformedToolCall | null {
+  const known = tools.find(t => t.name === call.name);
+  if (!known) {
+    let best: string | undefined;
+    let bestDist = Infinity;
+    for (const t of tools) {
+      const d = levenshtein(call.name.toLowerCase(), t.name.toLowerCase());
+      if (d < bestDist) {
+        bestDist = d;
+        best = t.name;
+      }
+    }
+    if (best && bestDist <= NAME_MATCH_THRESHOLD && bestDist < best.length) {
+      return { reason: `unknown tool "${call.name}"; did you mean "${best}"?`, suggestion: best };
+    }
+    return null;
+  }
+
+  const args = (call.arguments ?? {}) as Record<string, unknown>;
+  for (const req of known.parameters.required ?? []) {
+    const value = args[req];
+    if (value === undefined || value === null) {
+      return { reason: `missing required parameter "${req}"` };
+    }
+  }
+  return null;
+}
+
+/** The compact corrective message sent on a repair round-trip. */
+export function buildRepairMessage(call: ToolCall, fault: MalformedToolCall): string {
+  return `Your tool call to "${call.name}" was malformed: ${fault.reason}. Reply with ONLY the corrected tool call, nothing else.`;
+}
+
+/**
+ * JSON-schema envelope for a single tool call, used to grammar-constrain a
+ * repair reply via Ollama's `format` parameter. Constraining every response
+ * would break prose, so this is only ever applied on the repair round-trip.
+ */
+export function buildToolCallEnvelopeSchema(toolNames: string[]): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      name: toolNames.length > 0 ? { type: 'string', enum: toolNames } : { type: 'string' },
+      arguments: { type: 'object' },
+    },
+    required: ['name', 'arguments'],
+  };
+}
+
+/**
+ * Extract a corrected tool call from a repair response. Accepts either a native
+ * tool call (Ollama returned `tool_calls`) or a grammar-constrained JSON
+ * envelope in the text content (`{"name":...,"arguments":{...}}`). Returns null
+ * when neither yields a usable call. `id` is preserved so the assistant/tool
+ * message threading stays intact.
+ */
+export function extractRepairedToolCall(
+  content: string,
+  nativeToolCalls: ToolCall[] | undefined,
+  id: string,
+): ToolCall | null {
+  if (nativeToolCalls && nativeToolCalls.length > 0) {
+    const first = nativeToolCalls[0];
+    return { id, name: first.name, arguments: first.arguments ?? {} };
+  }
+  const text = content.trim();
+  if (!text) return null;
+  // Pull the first balanced JSON object out of the reply (models often wrap it
+  // in prose or a code fence despite the "ONLY" instruction).
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}' && --depth === 0) {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) return null;
+  try {
+    const parsed = JSON.parse(text.slice(start, end + 1)) as { name?: unknown; arguments?: unknown };
+    if (typeof parsed.name !== 'string' || !parsed.name) return null;
+    const args = (parsed.arguments && typeof parsed.arguments === 'object')
+      ? parsed.arguments as Record<string, unknown>
+      : {};
+    return { id, name: parsed.name, arguments: args };
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Capability detection (feature 6)
+// ============================================================================
+
+export interface LocalModelProfile {
+  provider: LLMProvider;
+  model: string;
+  baseUrl?: string;
+  contextLength: number;
+  supportsNativeToolCalls: boolean;
+  supportsJsonSchemaFormat: boolean;
+  /** Raw Ollama capability list when available (e.g. ['completion','tools',...]). */
+  capabilities?: string[];
+}
+
+/**
+ * Heuristic native-tool-call support by model family. Only consulted when the
+ * backend does not report capabilities directly (older Ollama, non-Ollama local
+ * servers). Errs toward the families known to emit reliable tool calls.
+ */
+export function familySupportsNativeTools(model: string): boolean {
+  const m = model.toLowerCase();
+  const families = [
+    'llama3.1', 'llama-3.1', 'llama3.2', 'llama-3.2', 'llama3.3', 'llama-3.3', 'llama4', 'llama-4',
+    'qwen2.5', 'qwen3', 'mistral', 'mixtral', 'devstral', 'command-r',
+    'hermes', 'firefunction', 'functionary', 'gemma4', 'gpt-oss',
+  ];
+  return families.some(f => m.includes(f));
+}
+
+function normalizeOllamaBase(url: string | undefined): string {
+  let base = url || 'http://localhost:11434';
+  if (base.endsWith('/v1')) base = base.slice(0, -3);
+  return base;
+}
+
+async function probeOllama(baseUrl: string, model: string): Promise<{ capabilities?: string[]; contextLength?: number }> {
+  const response = await fetch(`${baseUrl}/api/show`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: model }),
+  });
+  if (!response.ok) throw new Error(`Ollama /api/show returned ${response.status}`);
+  const data = await response.json() as {
+    capabilities?: string[];
+    model_info?: Record<string, unknown>;
+    parameters?: string;
+  };
+  let contextLength: number | undefined;
+  if (data.model_info) {
+    const ctxKey = Object.keys(data.model_info).find(k => k.includes('context_length') || k.includes('context_window'));
+    if (ctxKey && typeof data.model_info[ctxKey] === 'number') {
+      contextLength = data.model_info[ctxKey] as number;
+    }
+  }
+  if (data.parameters) {
+    const numCtx = data.parameters.match(/num_ctx\s+(\d+)/);
+    if (numCtx) contextLength = parseInt(numCtx[1], 10);
+  }
+  return { capabilities: data.capabilities, contextLength };
+}
+
+// Per-session cache: a CLI process is one session, so a module-level map is the
+// right lifetime. Keyed by provider|model|baseUrl.
+const profileCache = new Map<string, LocalModelProfile>();
+
+/** Clear the per-session capability cache (tests only). */
+export function clearLocalModelProfileCache(): void {
+  profileCache.clear();
+}
+
+/**
+ * Resolve a local model's capability profile, caching per session.
+ *
+ *  - contextLength: Ollama /api/show model_info, else the family default.
+ *  - supportsNativeToolCalls: Ollama `capabilities` includes 'tools' when
+ *    reported, else a family heuristic.
+ *  - supportsJsonSchemaFormat: true only for native Ollama (the /api/chat
+ *    `format` path); other local servers don't share that parameter.
+ *
+ * Never throws: a failed probe degrades to heuristics.
+ */
+export async function getLocalModelProfile(
+  provider: LLMProvider,
+  model: string,
+  baseUrl?: string,
+): Promise<LocalModelProfile> {
+  const url = baseUrl ?? config.getBaseUrl(provider);
+  const key = `${provider}|${model}|${url ?? ''}`;
+  const cached = profileCache.get(key);
+  if (cached) return cached;
+
+  let capabilities: string[] | undefined;
+  let contextLength = getModelContextLimit(provider, model);
+  let supportsNativeToolCalls = familySupportsNativeTools(model);
+  const supportsJsonSchemaFormat = provider === 'ollama';
+
+  if (provider === 'ollama') {
+    try {
+      const probe = await probeOllama(normalizeOllamaBase(url), model);
+      if (probe.capabilities) {
+        capabilities = probe.capabilities;
+        supportsNativeToolCalls = probe.capabilities.includes('tools');
+      }
+      if (probe.contextLength && probe.contextLength > 0) contextLength = probe.contextLength;
+    } catch {
+      // Keep heuristic values.
+    }
+  }
+
+  const profile: LocalModelProfile = {
+    provider,
+    model,
+    baseUrl: url,
+    contextLength,
+    supportsNativeToolCalls,
+    supportsJsonSchemaFormat,
+    capabilities,
+  };
+  profileCache.set(key, profile);
+  return profile;
+}
+
+// ============================================================================
+// System prompt selection (feature 5)
+// ============================================================================
+
+/**
+ * Pick the system prompt for a provider: the compact variant for a local
+ * backend, the full prompt for cloud. The single seam every prompt-building call
+ * site routes through, so provider checks are not scattered.
+ *
+ * The `auto` sentinel resolves to the full prompt (auto only selects a local
+ * backend when no cloud provider is configured, an edge the request-time schema
+ * simplification and repair loop still cover).
+ */
+export function getSystemPromptForProvider(provider: LLMProvider, baseUrl?: string): string {
+  return getSystemPrompt({ compact: isLocalBackend(provider, baseUrl) });
+}
+
+/** Rough token estimate for a raw string (~4 chars/token). */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -8,7 +8,8 @@ import * as config from '../config.js';
 import { withRetry } from '../errors.js';
 import type { Message, Tool, LLMResponse, LLMProvider } from '../types.js';
 import { DEFAULT_MODELS } from '../types.js';
-import { validateLLMResponse, type StreamCallback, type RetryCallback } from './types.js';
+import { validateLLMResponse, type StreamCallback, type RetryCallback, type ChatOptions } from './types.js';
+import { isLocalBackend, simplifyToolsForLocal } from '../local-model.js';
 import { chatAnthropic } from './anthropic.js';
 import { chatGoogle } from './google.js';
 import { chatOpenAI } from './openai.js';
@@ -80,22 +81,29 @@ export async function chat(
   tools: Tool[],
   model?: string,
   onToken?: StreamCallback,
-  onRetry?: RetryCallback
+  onRetry?: RetryCallback,
+  options?: ChatOptions
 ): Promise<LLMResponse> {
   const actualProvider = selectProvider(provider);
   const actualModel = model || DEFAULT_MODELS[actualProvider];
+
+  // Local backends see a simplified (but execution-lossless) tool schema:
+  // first-sentence descriptions, capped enums, and the edit_file anchor_hash
+  // param. Cloud providers get the full schema unchanged. This is the single
+  // seam for feature 1 — provider functions just serialize whatever they get.
+  const backendTools = isLocalBackend(actualProvider) ? simplifyToolsForLocal(tools) : tools;
 
   const doChat = async (): Promise<LLMResponse> => {
     let response: LLMResponse;
     switch (actualProvider) {
       case 'anthropic':
-        response = await chatAnthropic(messages, tools, actualModel, onToken);
+        response = await chatAnthropic(messages, backendTools, actualModel, onToken);
         break;
       case 'google':
-        response = await chatGoogle(messages, tools, actualModel, onToken);
+        response = await chatGoogle(messages, backendTools, actualModel, onToken);
         break;
       case 'openai':
-        response = await chatOpenAI(messages, tools, actualModel, onToken);
+        response = await chatOpenAI(messages, backendTools, actualModel, onToken);
         break;
       case 'openrouter':
       case 'together':
@@ -104,22 +112,22 @@ export async function chat(
       case 'mistral':
       case 'ai21':
       case 'huggingface':
-        response = await chatOpenAICompatible(actualProvider, messages, tools, actualModel, onToken);
+        response = await chatOpenAICompatible(actualProvider, messages, backendTools, actualModel, onToken);
         break;
       case 'ollama':
-        response = await chatOllama(messages, tools, actualModel, onToken);
+        response = await chatOllama(messages, backendTools, actualModel, onToken, options);
         break;
       case 'litellm':
-        response = await chatOpenAICompatible(actualProvider, messages, tools, actualModel, onToken);
+        response = await chatOpenAICompatible(actualProvider, messages, backendTools, actualModel, onToken);
         break;
       case 'bedrock': {
         const bedrockBase = config.getBaseUrl('bedrock');
         if (bedrockBase) {
           // Gateway/proxy mode (existing)
-          response = await chatOpenAICompatible(actualProvider, messages, tools, actualModel, onToken);
+          response = await chatOpenAICompatible(actualProvider, messages, backendTools, actualModel, onToken);
         } else {
           // Native AWS mode
-          response = await chatBedrock(messages, tools, actualModel, onToken);
+          response = await chatBedrock(messages, backendTools, actualModel, onToken);
         }
         break;
       }
@@ -140,5 +148,5 @@ export async function chat(
 
 // Re-export everything from sub-modules for public API
 export { needsSummarization, getContextHealth, estimateContextUsage } from './types.js';
-export type { StreamCallback, RetryCallback } from './types.js';
+export type { StreamCallback, RetryCallback, ChatOptions } from './types.js';
 export { requiresResponsesAPI, toResponsesInput, toResponsesTools } from './openai.js';

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -14,7 +14,7 @@
 
 import * as config from '../config.js';
 import type { Message, Tool, LLMResponse, ToolCall } from '../types.js';
-import { debugLog, type StreamCallback } from './types.js';
+import { debugLog, type StreamCallback, type ChatOptions } from './types.js';
 import { getOllamaFallbackModel } from '../model-detection.js';
 
 // ============================================================================
@@ -49,6 +49,8 @@ interface OllamaChatRequest {
   messages: OllamaMessage[];
   tools?: OllamaTool[];
   stream: boolean;
+  /** JSON-schema grammar constraint (repair round-trip only). */
+  format?: unknown;
 }
 
 interface OllamaChatResponse {
@@ -225,7 +227,8 @@ export async function chatOllama(
   messages: Message[],
   tools: Tool[],
   model: string,
-  onToken?: StreamCallback
+  onToken?: StreamCallback,
+  options?: ChatOptions
 ): Promise<LLMResponse> {
   const baseUrl = getBaseUrl();
   const skipCount = toolUnsupportedModels.get(model) ?? 0;
@@ -241,10 +244,10 @@ export async function chatOllama(
   if (skipTools && tools.length > 0) {
     debugLog(`ollama: skipping tools for ${model} (retry in ${skipCount - 1} calls)`);
   }
-  debugLog(`ollama native request: model=${model}, tools=${ollamaTools.length}, stream=${!!onToken}`);
+  debugLog(`ollama native request: model=${model}, tools=${ollamaTools.length}, stream=${!!onToken}, format=${!!options?.format}`);
 
   try {
-    return await doChat(baseUrl, model, ollamaMessages, ollamaTools, onToken);
+    return await doChat(baseUrl, model, ollamaMessages, ollamaTools, onToken, options?.format);
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
 
@@ -270,20 +273,38 @@ async function doChat(
   model: string,
   messages: OllamaMessage[],
   tools: OllamaTool[],
-  onToken?: StreamCallback
+  onToken?: StreamCallback,
+  format?: unknown
 ): Promise<LLMResponse> {
   const requestBody: OllamaChatRequest = {
     model,
     messages,
     tools: tools.length > 0 ? tools : undefined,
     stream: !!onToken,
+    ...(format !== undefined ? { format } : {}),
   };
 
-  const response = await fetch(`${baseUrl}/api/chat`, {
+  let response = await fetch(`${baseUrl}/api/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(requestBody),
   });
+
+  // Grammar-constrained `format` is best-effort: if this Ollama build rejects
+  // the schema (older versions, or a server that doesn't implement it), degrade
+  // silently and retry the same request without it rather than failing the call.
+  if (!response.ok && format !== undefined) {
+    const peek = await response.clone().text().catch(() => '');
+    if (response.status === 400 || /format/i.test(peek)) {
+      debugLog(`ollama: format param rejected (${response.status}), retrying without it`);
+      const { format: _dropped, ...withoutFormat } = requestBody;
+      response = await fetch(`${baseUrl}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(withoutFormat),
+      });
+    }
+  }
 
   if (!response.ok) {
     const errText = await response.text();

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -40,6 +40,15 @@ export type StreamCallback = (token: string) => void;
 export type RetryCallback = (attempt: number, error: Error, delayMs: number) => void;
 
 /**
+ * Per-call provider options. Currently only Ollama's grammar-constrained
+ * `format` (a JSON schema) — passed on the repair round-trip to force a
+ * well-formed tool-call envelope. Ignored by every other provider.
+ */
+export interface ChatOptions {
+  format?: unknown;
+}
+
+/**
  * Extract text from MessageContent
  */
 export function getTextContent(content: Message['content']): string {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -16,6 +16,7 @@ import { getPluginTools, isPluginTool, executePluginTool } from './plugins.js';
 import config from './config.js';
 import { generateDiff as generateFileDiff } from './diff.js';
 import { fleetActive, fleetMirrorToolCall } from './fleet.js';
+import { computeAnchorHash, anchorHashFooter } from './local-model.js';
 
 /**
  * Available tools for the agent
@@ -380,13 +381,24 @@ function validatePath(filePath: string, cwd: string): string {
 }
 
 /**
+ * Options that vary tool execution by the active backend without threading
+ * provider identity through every call. `appendAnchorHash` makes read_file emit
+ * the current content hash (local backends only) so the model can echo it back
+ * on a subsequent anchored edit_file (feature 4).
+ */
+export interface ExecuteToolOptions {
+  appendAnchorHash?: boolean;
+}
+
+/**
  * Execute a tool call
  */
 export async function executeTool(
   toolCall: ToolCall,
   cwd: string,
   timeout = 60000,
-  onOutput?: (chunk: string) => void
+  onOutput?: (chunk: string) => void,
+  options?: ExecuteToolOptions
 ): Promise<ToolResult> {
   const { id, name, arguments: args } = toolCall;
 
@@ -416,7 +428,7 @@ export async function executeTool(
         if (typeof args.path !== 'string') {
           return { toolCallId: id, result: 'Error: path must be a string', isError: true };
         }
-        result = await readFile(args.path, cwd);
+        result = await readFile(args.path, cwd, options?.appendAnchorHash === true);
         break;
       }
 
@@ -614,7 +626,10 @@ export async function executeTool(
           return { toolCallId: id, result: 'Error: new_string must be a string', isError: true };
         }
         const replaceAll = args.replace_all === true;
-        result = await editFile(args.path, args.old_string, args.new_string, replaceAll, cwd);
+        // anchor_hash is optional and accepted from any caller; it is only
+        // advertised in the simplified local schema (feature 4).
+        const anchorHash = typeof args.anchor_hash === 'string' ? args.anchor_hash : undefined;
+        result = await editFile(args.path, args.old_string, args.new_string, replaceAll, cwd, anchorHash);
         break;
       }
 
@@ -954,8 +969,12 @@ async function executeShell(command: string, cwd: string, timeout: number, onOut
 
 /**
  * Read a file
+ *
+ * When `appendAnchorHash` is set (local backends only), the current content hash
+ * is appended so the model can echo it back on a subsequent anchored edit_file
+ * (stale-view protection, feature 4).
  */
-async function readFile(filePath: string, cwd: string): Promise<string> {
+async function readFile(filePath: string, cwd: string, appendAnchorHash = false): Promise<string> {
   const absPath = validatePath(filePath, cwd);
 
   if (!fs.existsSync(absPath)) {
@@ -980,7 +999,8 @@ async function readFile(filePath: string, cwd: string): Promise<string> {
   const totalLines = content.split('\n').length;
   const header = `[file: ${filePath} \u2014 ${totalLines} line${totalLines !== 1 ? 's' : ''}]\n${'─'.repeat(40)}`;
 
-  return `${header}\n${content}`;
+  const footer = appendAnchorHash ? anchorHashFooter(computeAnchorHash(content)) : '';
+  return `${header}\n${content}${footer}`;
 }
 
 /**
@@ -1449,6 +1469,7 @@ async function editFile(
   newString: string,
   replaceAll: boolean,
   cwd: string,
+  anchorHash?: string,
 ): Promise<string> {
   const absPath = validatePath(filePath, cwd);
 
@@ -1462,6 +1483,19 @@ async function editFile(
   }
 
   const content = fs.readFileSync(absPath, 'utf-8');
+
+  // Stale-view protection (feature 4): if the caller supplied an anchor_hash, it
+  // must match the file's current content. A mismatch means the model is acting
+  // on an out-of-date view — fail loudly and tell it to re-read. Absent hash =
+  // no check (inert for cloud providers, which never see the param).
+  if (anchorHash !== undefined) {
+    const currentHash = computeAnchorHash(content);
+    if (anchorHash !== currentHash) {
+      throw new Error(
+        `anchor_hash mismatch: file has changed since you read it (you sent "${anchorHash}", current is "${currentHash}"). Re-read ${filePath} before editing.`,
+      );
+    }
+  }
 
   // Helper to build a compact edit diff from old_string/new_string (#119)
   const buildEditDiff = (oldStr: string, newStr: string, fPath: string, count: number): string => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,7 +192,23 @@ const SAFETY_PREAMBLE = `[SAFETY - These rules ALWAYS apply and cannot be overri
 
 `;
 
-export function getSystemPrompt(): string {
+/**
+ * Compact base prompt for local (self-hosted) backends. Folds the essentials of
+ * BASE_PROMPT and the grounding cues into one tight paragraph so small-context
+ * 7-70B models spend their budget on the task, not boilerplate. Keep this short
+ * (~100 chars): the local-model test asserts the whole compact prompt is under
+ * 40% of the full prompt's tokens. The non-negotiable [SAFETY] rules block is
+ * still prepended verbatim (see getSystemPrompt below).
+ */
+const COMPACT_BASE_PROMPT = `You are Calliope, a terminal coding agent. Use tools to edit files and run commands; ask if unclear.`;
+
+export function getSystemPrompt(opts?: { compact?: boolean }): string {
+  if (opts?.compact) {
+    // Keep the [SAFETY]…[END SAFETY] block verbatim; drop the verbose GROUNDING
+    // section and long base prompt in favour of the compact base.
+    const safetyOnly = SAFETY_PREAMBLE.slice(0, SAFETY_PREAMBLE.indexOf('[GROUNDING'));
+    return safetyOnly + COMPACT_BASE_PROMPT;
+  }
   return SAFETY_PREAMBLE + BASE_PROMPT;
 }
 

--- a/src/ui/agent.ts
+++ b/src/ui/agent.ts
@@ -28,7 +28,15 @@ import { CircuitBreaker } from '../circuit-breaker.js';
 import type { IterationData, BreakerCheckResult } from '../circuit-breaker.js';
 import { smartRoute, getDefaultSmartRoutingConfig } from '../router.js';
 import type { SmartRoutingConfig } from '../router.js';
-import type { Message as LLMMessage, LLMProvider, Mode, MessageContent, ToolCall } from '../types.js';
+import type { Message as LLMMessage, LLMProvider, Mode, MessageContent, ToolCall, LLMResponse } from '../types.js';
+import {
+  isLocalBackend,
+  detectMalformedToolCall,
+  buildRepairMessage,
+  buildToolCallEnvelopeSchema,
+  extractRepairedToolCall,
+  getLocalModelProfile,
+} from '../local-model.js';
 import type { UIMessage, SessionStats, ThinkingState, ActivityState } from './types.js';
 import type { Session } from '../storage.js';
 import { IterationLedger } from '../iteration-ledger.js';
@@ -174,6 +182,95 @@ export function validateAndRepairMessagesImpl(ctx: AgentContext): boolean {
 }
 
 // ============================================================================
+// Local-model tool-call repair (features 2 & 3)
+// ============================================================================
+
+/**
+ * When a LOCAL backend returns a malformed tool call, spend ONE corrective
+ * round-trip trying to fix it before the error surfaces naturally through
+ * executeTool. At most one call is repaired per response (cost control on
+ * self-hosted hardware); each call id gets at most one repair (`repairedCallIds`).
+ *
+ * On Ollama we grammar-constrain the repair reply with the tool-call envelope
+ * schema (the `format` param) — but only here, never on normal prose turns.
+ *
+ * Cloud backends and well-formed responses pass straight through unchanged.
+ */
+async function maybeRepairLocalToolCalls(
+  ctx: AgentContext,
+  baseMessages: LLMMessage[],
+  response: LLMResponse,
+  effectiveModel: string | undefined,
+  repairedCallIds: Set<string>,
+): Promise<LLMResponse> {
+  if (!response.toolCalls?.length) return response;
+  const provider = ctx.actualProvider as LLMProvider;
+  if (!isLocalBackend(provider)) return response;
+
+  const tools = getTools();
+  let target: { call: ToolCall; reason: string } | undefined;
+  for (const call of response.toolCalls) {
+    if (repairedCallIds.has(call.id)) continue;
+    const fault = detectMalformedToolCall(call, tools);
+    if (fault) {
+      target = { call, reason: fault.reason };
+      break;
+    }
+  }
+  if (!target) return response;
+
+  const { call, reason } = target;
+  repairedCallIds.add(call.id); // one repair per tool call, whatever the outcome
+  ctx.debugLog('repair', 'malformed local tool call', call.name, reason);
+  ctx.addMessage('system', `🔧 Malformed tool call from local model (${reason}); attempting one repair…`);
+
+  // Grammar-constrain the reply when the backend supports JSON-schema format.
+  let format: unknown;
+  try {
+    const profile = await getLocalModelProfile(provider, effectiveModel || ctx.actualModel);
+    if (profile.supportsJsonSchemaFormat) {
+      format = buildToolCallEnvelopeSchema(tools.map(t => t.name));
+    }
+  } catch {
+    // No format constraint — the corrective message alone still helps.
+  }
+
+  const repairMessages: LLMMessage[] = [
+    ...baseMessages,
+    { role: 'assistant', content: typeof response.content === 'string' ? response.content : '', toolCalls: response.toolCalls },
+    { role: 'user', content: buildRepairMessage(call, { reason }) },
+  ];
+
+  let repaired: LLMResponse;
+  try {
+    repaired = await chat(ctx.provider, repairMessages, tools, effectiveModel, undefined, undefined, format ? { format } : undefined);
+  } catch (err) {
+    ctx.ledger?.recordAction('repair', { tool: call.name }, 'error', reason);
+    ctx.debugLog('repair', 'repair round-trip threw', err instanceof Error ? err.message : String(err));
+    return response; // let the original error surface through executeTool
+  }
+
+  const corrected = extractRepairedToolCall(
+    typeof repaired.content === 'string' ? repaired.content : '',
+    repaired.toolCalls,
+    call.id,
+  );
+  if (!corrected) {
+    ctx.ledger?.recordAction('repair', { tool: call.name }, 'error', reason);
+    ctx.addMessage('system', '🔧 Repair produced no usable tool call; surfacing the original error.');
+    return response;
+  }
+
+  const stillBad = detectMalformedToolCall(corrected, tools);
+  ctx.ledger?.recordAction('repair', { tool: call.name, to: corrected.name }, stillBad ? 'error' : 'ok', stillBad?.reason);
+  ctx.addMessage('system', stillBad
+    ? '🔧 Repair did not resolve the malformed call; surfacing the error.'
+    : `🔧 Repaired tool call → ${corrected.name}`);
+
+  return { ...response, toolCalls: response.toolCalls.map(tc => (tc.id === call.id ? corrected : tc)) };
+}
+
+// ============================================================================
 // Run Agent
 // ============================================================================
 
@@ -230,6 +327,13 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
     : undefined;
   let runStatus: 'completed' | 'cancelled' | 'failed' | 'interrupted' | 'stopped' | undefined;
   let runErrorSummary: string | undefined;
+
+  // Local-backend behaviours (features 2 & 4): whether to append anchor hashes
+  // to read_file output, and which tool-call ids have already spent their one
+  // repair round-trip.
+  const localBackend = isLocalBackend(ctx.actualProvider as LLMProvider);
+  const executeOptions = { appendAnchorHash: localBackend };
+  const repairedCallIds = new Set<string>();
 
   // Check context limit and warn if approaching capacity
   // Uses model's actual context length from API when available
@@ -344,9 +448,14 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
         }
       }
 
-      const response = await chat(ctx.provider, validatedMessages, tools, effectiveModel, onToken, onRetry);
+      let response = await chat(ctx.provider, validatedMessages, tools, effectiveModel, onToken, onRetry);
       streamFlusher.flush(); // drain any batched tail before we swap to history
       ctx.debugLog('chat', 'GOT response', `toolCalls=${response.toolCalls?.length ?? 0}`);
+
+      // Local backends: give a malformed tool call ONE corrective round-trip
+      // before it surfaces as an execution error (features 2 & 3). No-op for
+      // cloud providers and well-formed responses.
+      response = await maybeRepairLocalToolCalls(ctx, validatedMessages, response, effectiveModel, repairedCallIds);
 
       // Update token stats and cost
       if (response.usage) {
@@ -513,7 +622,7 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
             const results = await executeParallel(
               executableTools,
               async (call) => {
-                const result = await executeTool(call, ctx.sessionRef.current?.projectPath ?? process.cwd());
+                const result = await executeTool(call, ctx.sessionRef.current?.projectPath ?? process.cwd(), 60000, undefined, executeOptions);
                 return { result: result.result, isError: result.isError };
               },
               (completed, total, current) => {
@@ -639,7 +748,7 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
                   detail: chunk.trimEnd().split('\n').pop()?.substring(0, 60),
                 });
               } : undefined;
-              const result = await executeTool(toolCall, ctx.sessionRef.current?.projectPath ?? process.cwd(), 60000, shellStreamCallback);
+              const result = await executeTool(toolCall, ctx.sessionRef.current?.projectPath ?? process.cwd(), 60000, shellStreamCallback, executeOptions);
               ctx.debugLog('tools', 'DONE', toolCall.name);
 
               // Record in iteration ledger

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -12,7 +12,8 @@ import * as path from 'path';
 import React from 'react';
 import * as config from '../config.js';
 import { selectProvider, getAvailableProviders } from '../providers/index.js';
-import { getSystemPrompt, MODE_CONFIG } from '../types.js';
+import { MODE_CONFIG } from '../types.js';
+import { getSystemPromptForProvider } from '../local-model.js';
 import { getAvailableModels, getModelContextLimit } from '../model-detection.js';
 import * as storage from '../storage.js';
 import * as mcp from '../mcp.js';
@@ -125,9 +126,10 @@ export interface CommandContext {
 }
 
 // Builds the full system prompt including memory context (project + global).
-// dir should be the project directory for the active/resumed session.
-function buildFullSystemPrompt(dir: string): string {
-  const base = getSystemPrompt();
+// dir should be the project directory for the active/resumed session; provider
+// selects the compact (local) vs full (cloud) base prompt (feature 5).
+function buildFullSystemPrompt(dir: string, provider: LLMProvider): string {
+  const base = getSystemPromptForProvider(provider);
   const mem = memory.buildMemoryContext(dir);
   return mem.trim() ? base + '\n\n--- Project Context ---\n' + mem : base;
 }
@@ -269,7 +271,7 @@ File references: @filename, ./path, /absolute/path`;
 
     case '/clear':
       ctx.setMessages([]);
-      ctx.llmMessages.current = [{ role: 'system', content: buildFullSystemPrompt(getActiveProjectDir(ctx)) }];
+      ctx.llmMessages.current = [{ role: 'system', content: buildFullSystemPrompt(getActiveProjectDir(ctx), ctx.actualProvider) }];
       ctx.ledger?.reset();
       ctx.setStats({ inputTokens: 0, outputTokens: 0, cost: 0, messageCount: 0 });
       resetContextWarnings(); // Reset context warning state
@@ -919,7 +921,7 @@ Stop a running loop with /loop stop`);
           ctx.llmMessages.current.length = 0;
           ctx.llmMessages.current.push({
             role: 'system',
-            content: buildFullSystemPrompt(getActiveProjectDir(ctx)),
+            content: buildFullSystemPrompt(getActiveProjectDir(ctx), ctx.actualProvider),
           });
           for (const msg of history) {
             if (msg.role === 'user' || msg.role === 'assistant') {

--- a/src/ui/state/use-chat-controller.ts
+++ b/src/ui/state/use-chat-controller.ts
@@ -12,7 +12,8 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useApp } from 'ink';
 import * as config from '../../config.js';
 import { selectProvider } from '../../providers/index.js';
-import { getSystemPrompt, DEFAULT_MODELS, supportsVision } from '../../types.js';
+import { DEFAULT_MODELS, supportsVision } from '../../types.js';
+import { getSystemPromptForProvider } from '../../local-model.js';
 import type { Message as LLMMessage, LLMProvider, Mode, MessageContent } from '../../types.js';
 import { getModelContextLimit } from '../../model-detection.js';
 import type { ModelInfo } from '../../model-detection.js';
@@ -106,7 +107,7 @@ export function useChatController(): ChatController {
   const sessionRef = useRef<storage.Session | null>(null);
   const undoStack = useRef<ConversationSnapshot[]>([]);
   const redoStack = useRef<ConversationSnapshot[]>([]);
-  const llmMessages = useRef<LLMMessage[]>([{ role: 'system', content: getSystemPrompt() }]);
+  const llmMessages = useRef<LLMMessage[]>([{ role: 'system', content: getSystemPromptForProvider(provider) }]);
   const ledgerRef = useRef<IterationLedger>(new IterationLedger());
   const circuitBreakerRef = useRef<CircuitBreaker>(makeCircuitBreaker());
   const smartRoutingConfigRef = useRef<SmartRoutingConfig>({
@@ -552,7 +553,7 @@ export function useChatController(): ChatController {
       if (history.length > 0) {
         llmMessages.current.length = 0;
         const activeCwd = sessionRef.current?.projectPath ?? process.cwd();
-        const basePrompt = getSystemPrompt();
+        const basePrompt = getSystemPromptForProvider(actualProvider);
         const memoryContext = memory.buildMemoryContext(activeCwd);
         llmMessages.current.push({
           role: 'system',
@@ -571,7 +572,7 @@ export function useChatController(): ChatController {
     }
     modal.setModalMode('none');
     modal.setPreviousSession(null);
-  }, [addMessage, estimateContextTokens, stats, modal]);
+  }, [addMessage, estimateContextTokens, stats, modal, actualProvider]);
 
   const handleSessionResumeNew = useCallback(() => {
     addMessage('system', '✓ Starting fresh session');
@@ -629,12 +630,12 @@ export function useChatController(): ChatController {
     modal.reset();
     queue.reset();
     loop.reset();
-    llmMessages.current = [{ role: 'system', content: getSystemPrompt() }];
+    llmMessages.current = [{ role: 'system', content: getSystemPromptForProvider(actualProvider) }];
     undoStack.current = [];
     redoStack.current = [];
     ledgerRef.current.reset();
     resetContextWarnings();
-  }, [proc, transcript, stats, modelState, modal, queue, loop]);
+  }, [proc, transcript, stats, modelState, modal, queue, loop, actualProvider]);
 
   // -- Mount initialization -------------------------------------------------
   useSessionInit({ sessionRef, ledgerRef, llmMessages, addMessage, onFleetInstruction: handleFleetInstruction });

--- a/tests/__snapshots__/local-model.test.ts.snap
+++ b/tests/__snapshots__/local-model.test.ts.snap
@@ -1,0 +1,113 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`simplifyToolsForLocal > snapshot: configure (verbose description) 1`] = `
+{
+  "description": "Read, set, or list Calliope configuration options.",
+  "name": "configure",
+  "parameters": {
+    "properties": {
+      "action": {
+        "description": "Action to perform: "get" reads a setting, "set" changes a setting, "list" shows…",
+        "enum": [
+          "get",
+          "set",
+          "list",
+        ],
+        "type": "string",
+      },
+      "category": {
+        "description": "Category to list options for (for list action): providers, layouts, all",
+        "enum": [
+          "providers",
+          "layouts",
+          "all",
+        ],
+        "type": "string",
+      },
+      "key": {
+        "description": "Config key name (for get/set actions)",
+        "type": "string",
+      },
+      "value": {
+        "description": "New value to set (for set action).",
+        "type": "string",
+      },
+    },
+    "required": [
+      "action",
+    ],
+    "type": "object",
+  },
+}
+`;
+
+exports[`simplifyToolsForLocal > snapshot: edit_file (gains anchor_hash) 1`] = `
+{
+  "description": "Edit a file by replacing an exact string.",
+  "name": "edit_file",
+  "parameters": {
+    "properties": {
+      "anchor_hash": {
+        "description": "Optional 8-char hash from the last read_file of this file (stale-edit guard); echo it to confirm your view is current.",
+        "type": "string",
+      },
+      "new_string": {
+        "description": "The string to replace old_string with",
+        "type": "string",
+      },
+      "old_string": {
+        "description": "The exact string to find and replace",
+        "type": "string",
+      },
+      "path": {
+        "description": "The path to the file to edit",
+        "type": "string",
+      },
+      "replace_all": {
+        "description": "If true, replace all occurrences.",
+        "type": "boolean",
+      },
+    },
+    "required": [
+      "path",
+      "old_string",
+      "new_string",
+    ],
+    "type": "object",
+  },
+}
+`;
+
+exports[`simplifyToolsForLocal > snapshot: git (enum + trimmed description) 1`] = `
+{
+  "description": "Execute git commands safely.",
+  "name": "git",
+  "parameters": {
+    "properties": {
+      "args": {
+        "description": "Additional arguments for the git command",
+        "type": "string",
+      },
+      "operation": {
+        "description": "Git operation: status, diff, log, branch, add, commit, push, pull, stash",
+        "enum": [
+          "status",
+          "diff",
+          "log",
+          "branch",
+          "add",
+          "commit",
+          "push",
+          "pull",
+          "stash",
+        ],
+        "type": "string",
+      },
+    },
+    "required": [
+      "operation",
+    ],
+    "type": "object",
+  },
+}
+`;

--- a/tests/agent-repair.test.ts
+++ b/tests/agent-repair.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Local-backend tool-call repair loop (#188 features 2 & 3), exercised through
+ * runAgentImpl. Verifies: a malformed tool call from a LOCAL backend triggers one
+ * corrective round-trip; a successfully-corrected call executes; a still-malformed
+ * repair surfaces the error without a second repair. Fully mocked (no network).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentContext } from '../src/ui/agent.js';
+import type { Message as LLMMessage, LLMProvider, Mode, Tool } from '../src/types.js';
+
+const chatMock = vi.fn();
+const executeToolMock = vi.fn();
+
+const READ_FILE_TOOL: Tool = {
+  name: 'read_file',
+  description: 'Read a file',
+  parameters: { type: 'object', properties: { path: { type: 'string', description: 'path' } }, required: ['path'] },
+};
+
+vi.mock('../src/config.js', () => ({
+  default: {},
+  get: vi.fn((key: string) => (key === 'maxIterations' ? 3 : undefined)),
+  getBaseUrl: vi.fn(() => 'http://localhost:11434'),
+}));
+
+vi.mock('../src/providers/index.js', () => ({
+  chat: (...args: unknown[]) => chatMock(...args),
+  getAvailableProviders: vi.fn(() => ['ollama']),
+}));
+
+vi.mock('../src/providers/types.js', () => ({
+  estimateContextUsage: vi.fn(() => ({ estimated: 100, limit: 100000, percent: 1, needsSummarization: false })),
+  needsSummarization: vi.fn(() => false),
+}));
+
+vi.mock('../src/tools.js', () => ({
+  executeTool: (...args: unknown[]) => executeToolMock(...args),
+  getTools: vi.fn(() => [READ_FILE_TOOL]),
+}));
+
+// Keep the real local-model helpers (detection/repair are pure); only stub the
+// network capability probe so the format decision is deterministic.
+vi.mock('../src/local-model.js', async (importActual) => {
+  const actual = await importActual<typeof import('../src/local-model.js')>();
+  return {
+    ...actual,
+    getLocalModelProfile: vi.fn(async () => ({
+      provider: 'ollama' as LLMProvider,
+      model: 'gemma4:31b',
+      contextLength: 262144,
+      supportsNativeToolCalls: true,
+      supportsJsonSchemaFormat: true,
+    })),
+  };
+});
+
+vi.mock('../src/types.js', () => ({
+  DEFAULT_MODELS: { ollama: 'gemma4:31b' },
+  RISK_CONFIG: {
+    none: { bar: '', color: 'dim', label: 'None' },
+    low: { bar: '#', color: 'green', label: 'Low' },
+    medium: { bar: '##', color: 'yellow', label: 'Medium' },
+    high: { bar: '###', color: 'red', label: 'High' },
+    critical: { bar: '####', color: 'red', label: 'CRITICAL' },
+  },
+  calculateCost: vi.fn(() => 0),
+}));
+
+vi.mock('../src/model-detection.js', () => ({
+  getModelContextLimit: vi.fn(() => 262144),
+  getModelMaxOutput: vi.fn(() => 8192),
+}));
+
+vi.mock('../src/risk.js', () => ({
+  assessToolRisk: vi.fn(() => ({ level: 'low', reason: '', canAutoApprove: true })),
+  requiresConfirmation: vi.fn(() => false),
+}));
+
+vi.mock('../src/errors.js', () => ({
+  formatError: vi.fn((e: unknown) => (e instanceof Error ? e.message : String(e))),
+  classifyError: vi.fn(() => ({ category: 'other' })),
+}));
+
+vi.mock('../src/storage.js', () => ({ saveMessageHistory: vi.fn(), recordCost: vi.fn() }));
+vi.mock('../src/hooks.js', () => ({ checkHooksAllow: vi.fn(async () => ({ allowed: true })), executeHooks: vi.fn(() => Promise.resolve()) }));
+vi.mock('../src/router.js', () => ({ routeRequest: vi.fn(), smartRoute: vi.fn(), getDefaultSmartRoutingConfig: vi.fn(() => ({ enabled: false })) }));
+vi.mock('../src/summarization.js', () => ({
+  validateMessageHistory: vi.fn((m: unknown[]) => m),
+  summarizeConversation: vi.fn((m: unknown[]) => ({ messages: m, summarizedCount: 0, originalTokens: 0, reducedTokens: 0, summary: '' })),
+  estimateTotalTokens: vi.fn(() => 100),
+  summarizeMessages: vi.fn(() => ''),
+}));
+vi.mock('../src/auto-compressor.js', () => ({ autoCompress: vi.fn(async (messages: unknown[]) => ({ compressed: false, messages })) }));
+vi.mock('../src/parallel-tools.js', () => ({
+  executeParallel: vi.fn(),
+  getParallelizationStats: vi.fn(() => ({ totalCalls: 1, maxParallel: 1, stages: 1 })),
+}));
+vi.mock('../src/ui/context.js', () => ({ checkAndWarnContextLimit: vi.fn() }));
+vi.mock('../src/circuit-breaker.js', () => ({ CircuitBreaker: vi.fn() }));
+vi.mock('../src/iteration-ledger.js', () => ({ IterationLedger: vi.fn() }));
+vi.mock('../src/checkpoint.js', () => ({ shouldCheckpoint: vi.fn(() => false), createCheckpoint: vi.fn() }));
+vi.mock('../src/prevent-sleep.js', () => ({ startPreventSleep: vi.fn(), stopPreventSleep: vi.fn() }));
+
+const { runAgentImpl } = await import('../src/ui/agent.js');
+
+function makeLedger() {
+  return {
+    getActiveRun: vi.fn(() => undefined),
+    startRun: vi.fn(() => 'run-1'),
+    getNextIterationNumber: vi.fn(() => 1),
+    startIteration: vi.fn(),
+    getFailedApproachesMessage: vi.fn(() => ''),
+    recordTokens: vi.fn(),
+    recordAction: vi.fn(),
+    endIteration: vi.fn(),
+    finishRun: vi.fn(),
+  };
+}
+
+function makeCtx() {
+  const collectedMessages: Array<{ type: string; content: string }> = [];
+  const llmMessages: LLMMessage[] = [];
+  const ledger = makeLedger();
+
+  const ctx = {
+    provider: 'ollama' as LLMProvider,
+    model: 'gemma4:31b',
+    mode: 'work' as Mode,
+    confirmMode: false,
+    autoRoute: false,
+    actualProvider: 'ollama',
+    actualModel: 'gemma4:31b',
+    stats: { messageCount: 0, inputTokens: 0, outputTokens: 0, cost: 0 },
+    ledger,
+
+    setStats: vi.fn((v: unknown) => { ctx.stats = typeof v === 'function' ? (v as (p: unknown) => unknown)(ctx.stats) : v; }),
+    setStreamingResponse: vi.fn(),
+    setThinkingState: vi.fn(),
+    setActivityState: vi.fn(),
+    setContextTokens: vi.fn(),
+    setIsProcessing: vi.fn(),
+    setQueuedMessages: vi.fn(),
+    setEditingQueueIndex: vi.fn(),
+    setLoopIteration: vi.fn(),
+    setLoopActive: vi.fn(),
+
+    llmMessages: { current: llmMessages },
+    queuedMessagesRef: { current: [] as string[] },
+    loopCancelledRef: { current: false },
+    sessionRef: { current: null },
+
+    addMessage: (type: string, content: string) => { collectedMessages.push({ type, content }); },
+    estimateContextTokens: vi.fn(() => 0),
+    validateAndRepairMessages: vi.fn(() => true),
+    debugLog: vi.fn(),
+    collectedMessages,
+    ledgerSpy: ledger,
+  } as unknown as AgentContext & { collectedMessages: Array<{ type: string; content: string }>; ledgerSpy: ReturnType<typeof makeLedger> };
+
+  return ctx;
+}
+
+const sys = (content: string) => (m: { type: string; content: string }) => m.type === 'system' && m.content.includes(content);
+
+beforeEach(() => {
+  chatMock.mockReset();
+  executeToolMock.mockReset();
+  executeToolMock.mockImplementation(async (toolCall: { id: string; arguments: Record<string, unknown> }) => {
+    if (typeof toolCall.arguments.path !== 'string') {
+      return { toolCallId: toolCall.id, result: 'Error: path must be a string', isError: true };
+    }
+    return { toolCallId: toolCall.id, result: 'file contents', isError: false };
+  });
+});
+
+describe('local-backend tool-call repair loop', () => {
+  it('repairs a malformed call via one corrective round-trip, then the fixed call executes', async () => {
+    chatMock
+      // main turn: malformed read_file (missing required path)
+      .mockResolvedValueOnce({ content: '', toolCalls: [{ id: 't1', name: 'read_file', arguments: {} }], finishReason: 'tool_use' })
+      // repair round-trip: corrected native tool call
+      .mockResolvedValueOnce({ content: '', toolCalls: [{ id: 'r1', name: 'read_file', arguments: { path: 'a.ts' } }], finishReason: 'tool_use' })
+      // next turn: final answer
+      .mockResolvedValueOnce({ content: 'done', toolCalls: [], finishReason: 'stop' });
+
+    const ctx = makeCtx();
+    await runAgentImpl(ctx, 'read a.ts');
+
+    // The corrected call reached execution, with the original id preserved.
+    expect(executeToolMock).toHaveBeenCalledTimes(1);
+    const executed = executeToolMock.mock.calls[0][0];
+    expect(executed).toMatchObject({ id: 't1', name: 'read_file', arguments: { path: 'a.ts' } });
+
+    // A corrective round-trip was sent, carrying the reason.
+    expect(chatMock).toHaveBeenCalledTimes(3);
+    const repairMessages = chatMock.mock.calls[1][1] as LLMMessage[];
+    const corrective = repairMessages[repairMessages.length - 1];
+    expect(corrective.role).toBe('user');
+    expect(String(corrective.content)).toContain('malformed');
+    expect(String(corrective.content)).toContain('missing required parameter "path"');
+
+    // User-visible + ledger signals.
+    expect(ctx.collectedMessages.some(sys('Malformed tool call'))).toBe(true);
+    expect(ctx.collectedMessages.some(sys('Repaired tool call'))).toBe(true);
+    expect(ctx.ledgerSpy.recordAction).toHaveBeenCalledWith('repair', expect.anything(), 'ok', undefined);
+  });
+
+  it('constrains the repair reply with the Ollama format param', async () => {
+    chatMock
+      .mockResolvedValueOnce({ content: '', toolCalls: [{ id: 't1', name: 'read_file', arguments: {} }], finishReason: 'tool_use' })
+      .mockResolvedValueOnce({ content: '{"name":"read_file","arguments":{"path":"b.ts"}}', toolCalls: undefined, finishReason: 'stop' })
+      .mockResolvedValueOnce({ content: 'done', toolCalls: [], finishReason: 'stop' });
+
+    const ctx = makeCtx();
+    await runAgentImpl(ctx, 'read b.ts');
+
+    // The repair round-trip (2nd chat call) passed a format schema in options.
+    const repairOptions = chatMock.mock.calls[1][6];
+    expect(repairOptions).toBeDefined();
+    expect(repairOptions.format).toMatchObject({ type: 'object', required: ['name', 'arguments'] });
+
+    // The grammar-constrained JSON envelope was parsed and executed.
+    expect(executeToolMock.mock.calls[0][0]).toMatchObject({ name: 'read_file', arguments: { path: 'b.ts' } });
+  });
+
+  it('surfaces the error when the repair is still malformed — no second repair', async () => {
+    chatMock
+      // main turn: malformed
+      .mockResolvedValueOnce({ content: '', toolCalls: [{ id: 't1', name: 'read_file', arguments: {} }], finishReason: 'tool_use' })
+      // repair round-trip: STILL missing path
+      .mockResolvedValueOnce({ content: '', toolCalls: [{ id: 'r1', name: 'read_file', arguments: {} }], finishReason: 'tool_use' })
+      // next turn: final answer
+      .mockResolvedValueOnce({ content: 'giving up', toolCalls: [], finishReason: 'stop' });
+
+    const ctx = makeCtx();
+    await runAgentImpl(ctx, 'read c.ts');
+
+    // Exactly one repair round-trip (3 chat calls total: main, repair, final).
+    expect(chatMock).toHaveBeenCalledTimes(3);
+    // The still-malformed call reached execution and errored (surfaced naturally).
+    expect(executeToolMock).toHaveBeenCalledTimes(1);
+    expect(executeToolMock.mock.calls[0][0]).toMatchObject({ name: 'read_file', arguments: {} });
+    expect(ctx.collectedMessages.some(sys('did not resolve'))).toBe(true);
+    expect(ctx.ledgerSpy.recordAction).toHaveBeenCalledWith('repair', expect.anything(), 'error', expect.anything());
+  });
+
+  it('does not repair well-formed local tool calls (no extra round-trip)', async () => {
+    chatMock
+      .mockResolvedValueOnce({ content: '', toolCalls: [{ id: 't1', name: 'read_file', arguments: { path: 'a.ts' } }], finishReason: 'tool_use' })
+      .mockResolvedValueOnce({ content: 'done', toolCalls: [], finishReason: 'stop' });
+
+    const ctx = makeCtx();
+    await runAgentImpl(ctx, 'read a.ts');
+
+    // No repair round-trip: 2 chat calls (main + final), tool executed once.
+    expect(chatMock).toHaveBeenCalledTimes(2);
+    expect(executeToolMock).toHaveBeenCalledTimes(1);
+    expect(ctx.collectedMessages.some(sys('Malformed tool call'))).toBe(false);
+  });
+});

--- a/tests/local-model.test.ts
+++ b/tests/local-model.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Local-model excellence (#188) — unit tests for src/local-model.ts.
+ *
+ * Covers: backend detection, tool-schema simplification (snapshots for three
+ * representative tools), anchor hashing, malformed-call detection + repair
+ * helpers, the capability profile against mocked /api/show variations, and the
+ * compact system-prompt token ratio.
+ *
+ * Fully mocked — no network.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Tool, ToolCall } from '../src/types.js';
+
+vi.mock('../src/config.js', () => ({
+  default: {},
+  getBaseUrl: vi.fn((provider: string) => {
+    if (provider === 'ollama') return 'http://localhost:11434';
+    if (provider === 'litellm') return 'http://localhost:4000';
+    return undefined; // openai-compat, bedrock: not configured
+  }),
+}));
+
+import {
+  isLoopbackUrl,
+  isLocalBackend,
+  simplifyToolForLocal,
+  simplifyToolsForLocal,
+  firstSentence,
+  computeAnchorHash,
+  anchorHashFooter,
+  levenshtein,
+  detectMalformedToolCall,
+  buildRepairMessage,
+  buildToolCallEnvelopeSchema,
+  extractRepairedToolCall,
+  getLocalModelProfile,
+  clearLocalModelProfileCache,
+  familySupportsNativeTools,
+  getSystemPromptForProvider,
+  estimateTokens,
+  ANCHOR_HASH_KEY,
+} from '../src/local-model.js';
+import { getSystemPrompt } from '../src/types.js';
+import { TOOLS } from '../src/tools.js';
+
+const tool = (name: string): Tool => {
+  const t = TOOLS.find(x => x.name === name);
+  if (!t) throw new Error(`no such tool ${name}`);
+  return t;
+};
+
+const call = (name: string, args: Record<string, unknown> = {}): ToolCall => ({ id: 'c1', name, arguments: args });
+
+// ===========================================================================
+// Backend detection
+// ===========================================================================
+
+describe('isLoopbackUrl', () => {
+  it.each([
+    ['http://localhost:11434', true],
+    ['http://127.0.0.1:8000', true],
+    ['http://0.0.0.0:4000/v1', true],
+    ['http://[::1]:1234', true],
+    ['http://host.docker.internal:11434', true],
+    ['http://gpu-box.local:8000', true],
+    ['https://api.openai.com/v1', false],
+    ['https://openrouter.ai/api/v1', false],
+    ['http://192.168.1.50:8000', false], // private LAN, but not loopback
+  ])('%s -> %s', (url, expected) => {
+    expect(isLoopbackUrl(url)).toBe(expected);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isLoopbackUrl(undefined)).toBe(false);
+  });
+
+  it('falls back to substring match for a non-URL string', () => {
+    expect(isLoopbackUrl('localhost')).toBe(true);
+    expect(isLoopbackUrl('not a url at all')).toBe(false);
+  });
+});
+
+describe('isLocalBackend', () => {
+  it('treats ollama as always local (no base URL needed)', () => {
+    expect(isLocalBackend('ollama')).toBe(true);
+  });
+
+  it('treats litellm/openai-compat as local only when the base URL is loopback', () => {
+    expect(isLocalBackend('litellm', 'http://localhost:4000')).toBe(true);
+    expect(isLocalBackend('litellm', 'https://litellm.mycorp.com')).toBe(false);
+    expect(isLocalBackend('openai-compat', 'http://127.0.0.1:1234')).toBe(true);
+    expect(isLocalBackend('openai-compat', 'https://api.hosted.ai')).toBe(false);
+  });
+
+  it('resolves the base URL from config when not passed', () => {
+    // litellm config default is loopback -> local; openai-compat is unset -> cloud.
+    expect(isLocalBackend('litellm')).toBe(true);
+    expect(isLocalBackend('openai-compat')).toBe(false);
+  });
+
+  it('treats hosted providers and the auto sentinel as cloud', () => {
+    for (const p of ['anthropic', 'openai', 'google', 'mistral', 'bedrock', 'auto'] as const) {
+      expect(isLocalBackend(p)).toBe(false);
+    }
+  });
+});
+
+// ===========================================================================
+// Schema simplification (feature 1)
+// ===========================================================================
+
+describe('firstSentence', () => {
+  it('keeps only the first sentence', () => {
+    expect(firstSentence('Edit a file. Prefer this over write_file.', 200)).toBe('Edit a file.');
+  });
+  it('collapses multi-line descriptions to the first line/sentence', () => {
+    expect(firstSentence('Read, set, or list options.\n\nCONFIGURABLE:\n- a\n- b', 200))
+      .toBe('Read, set, or list options.');
+  });
+  it('caps overly long single sentences with an ellipsis', () => {
+    const long = 'x'.repeat(120);
+    const out = firstSentence(long, 80);
+    expect(out.length).toBe(80);
+    expect(out.endsWith('…')).toBe(true);
+  });
+  it('handles empty/undefined', () => {
+    expect(firstSentence('', 80)).toBe('');
+    expect(firstSentence(undefined, 80)).toBe('');
+  });
+});
+
+describe('simplifyToolsForLocal', () => {
+  it('is a no-op shape for an empty tool set', () => {
+    expect(simplifyToolsForLocal([])).toEqual([]);
+  });
+
+  it('trims a verbose multi-line tool description to its first sentence', () => {
+    const simplified = simplifyToolForLocal(tool('configure'));
+    expect(simplified.description).toBe('Read, set, or list Calliope configuration options.');
+    expect(simplified.description).not.toContain('\n');
+    expect(simplified.description.length).toBeLessThan(tool('configure').description.length);
+  });
+
+  it('adds the optional anchor_hash param to edit_file (local schema only)', () => {
+    const simplified = simplifyToolForLocal(tool('edit_file'));
+    expect(simplified.parameters.properties[ANCHOR_HASH_KEY]).toBeDefined();
+    expect(simplified.parameters.properties[ANCHOR_HASH_KEY].type).toBe('string');
+    // anchor_hash is optional — never added to required.
+    expect(simplified.parameters.required).not.toContain(ANCHOR_HASH_KEY);
+    // The real (cloud) schema does NOT carry it.
+    expect(tool('edit_file').parameters.properties[ANCHOR_HASH_KEY]).toBeUndefined();
+  });
+
+  it('does not add anchor_hash to other tools', () => {
+    expect(simplifyToolForLocal(tool('read_file')).parameters.properties[ANCHOR_HASH_KEY]).toBeUndefined();
+  });
+
+  it('preserves required params, types, enums, and array items (lossless for execution)', () => {
+    const git = simplifyToolForLocal(tool('git'));
+    expect(git.parameters.required).toEqual(['operation']);
+    expect(git.parameters.properties.operation.type).toBe('string');
+    expect(git.parameters.properties.operation.enum).toEqual(
+      tool('git').parameters.properties.operation.enum,
+    );
+    const askQ = simplifyToolForLocal(tool('ask_question'));
+    expect(askQ.parameters.properties.options.items).toEqual({ type: 'string' });
+  });
+
+  it('caps enum listings beyond the limit', () => {
+    const bigEnum: Tool = {
+      name: 'pick',
+      description: 'Pick one.',
+      parameters: {
+        type: 'object',
+        properties: {
+          choice: { type: 'string', description: 'the choice', enum: Array.from({ length: 30 }, (_, i) => `opt${i}`) },
+        },
+        required: ['choice'],
+      },
+    };
+    const simplified = simplifyToolForLocal(bigEnum);
+    expect(simplified.parameters.properties.choice.enum).toHaveLength(12);
+    expect(simplified.parameters.properties.choice.enum![0]).toBe('opt0');
+  });
+
+  // Snapshots: full vs simplified for three representative tools.
+  it('snapshot: configure (verbose description)', () => {
+    expect(simplifyToolForLocal(tool('configure'))).toMatchSnapshot();
+  });
+  it('snapshot: edit_file (gains anchor_hash)', () => {
+    expect(simplifyToolForLocal(tool('edit_file'))).toMatchSnapshot();
+  });
+  it('snapshot: git (enum + trimmed description)', () => {
+    expect(simplifyToolForLocal(tool('git'))).toMatchSnapshot();
+  });
+});
+
+// ===========================================================================
+// Anchor hashes (feature 4)
+// ===========================================================================
+
+describe('computeAnchorHash', () => {
+  it('is a stable 8-char sha256 prefix', () => {
+    const h = computeAnchorHash('hello world');
+    expect(h).toHaveLength(8);
+    expect(h).toMatch(/^[0-9a-f]{8}$/);
+    expect(computeAnchorHash('hello world')).toBe(h); // deterministic
+  });
+  it('changes when content changes', () => {
+    expect(computeAnchorHash('a')).not.toBe(computeAnchorHash('b'));
+  });
+  it('anchorHashFooter embeds the hash and instructs re-echo', () => {
+    const footer = anchorHashFooter('deadbeef');
+    expect(footer).toContain('deadbeef');
+    expect(footer).toContain('anchor_hash');
+  });
+});
+
+// ===========================================================================
+// Malformed detection + repair helpers (features 2 & 3)
+// ===========================================================================
+
+describe('levenshtein', () => {
+  it.each([
+    ['read_file', 'read_file', 0],
+    ['reae_file', 'read_file', 1],
+    ['readfile', 'read_file', 1],
+    ['', 'abc', 3],
+    ['abc', '', 3],
+    ['kitten', 'sitting', 3],
+  ])('d(%s,%s)=%i', (a, b, d) => {
+    expect(levenshtein(a, b)).toBe(d);
+  });
+});
+
+describe('detectMalformedToolCall', () => {
+  const tools = [tool('read_file'), tool('shell'), tool('edit_file')];
+
+  it('returns null for a well-formed call', () => {
+    expect(detectMalformedToolCall(call('read_file', { path: 'a.ts' }), tools)).toBeNull();
+  });
+
+  it('flags an unknown tool name with a close match and suggests the neighbour', () => {
+    const fault = detectMalformedToolCall(call('reae_file', { path: 'a.ts' }), tools);
+    expect(fault).not.toBeNull();
+    expect(fault!.suggestion).toBe('read_file');
+    expect(fault!.reason).toContain('read_file');
+  });
+
+  it('returns null for an unknown tool with no close match (surfaces naturally)', () => {
+    expect(detectMalformedToolCall(call('launch_rockets', {}), tools)).toBeNull();
+  });
+
+  it('flags a missing required parameter (also how empty-args {} presents)', () => {
+    const fault = detectMalformedToolCall(call('read_file', {}), tools);
+    expect(fault).not.toBeNull();
+    expect(fault!.reason).toContain('path');
+  });
+
+  it('treats null-valued required params as missing', () => {
+    expect(detectMalformedToolCall(call('shell', { command: null }), tools)).not.toBeNull();
+  });
+});
+
+describe('buildRepairMessage', () => {
+  it('embeds the tool name and reason and asks for ONLY the corrected call', () => {
+    const msg = buildRepairMessage(call('read_file', {}), { reason: 'missing required parameter "path"' });
+    expect(msg).toContain('read_file');
+    expect(msg).toContain('missing required parameter "path"');
+    expect(msg).toContain('ONLY');
+  });
+});
+
+describe('buildToolCallEnvelopeSchema', () => {
+  it('constrains name to the known tools and requires name+arguments', () => {
+    const schema = buildToolCallEnvelopeSchema(['read_file', 'shell']) as any;
+    expect(schema.type).toBe('object');
+    expect(schema.properties.name.enum).toEqual(['read_file', 'shell']);
+    expect(schema.required).toEqual(['name', 'arguments']);
+  });
+  it('drops the enum when no tool names are supplied', () => {
+    const schema = buildToolCallEnvelopeSchema([]) as any;
+    expect(schema.properties.name.enum).toBeUndefined();
+  });
+});
+
+describe('extractRepairedToolCall', () => {
+  it('prefers a native tool call and preserves the original id', () => {
+    const out = extractRepairedToolCall('', [{ id: 'new', name: 'read_file', arguments: { path: 'a.ts' } }], 'orig');
+    expect(out).toEqual({ id: 'orig', name: 'read_file', arguments: { path: 'a.ts' } });
+  });
+
+  it('parses a grammar-constrained JSON envelope from content', () => {
+    const content = '{\n  "name": "read_file",\n  "arguments": { "path": "./README.md" }\n}';
+    const out = extractRepairedToolCall(content, undefined, 'orig');
+    expect(out).toEqual({ id: 'orig', name: 'read_file', arguments: { path: './README.md' } });
+  });
+
+  it('digs the envelope out of surrounding prose / code fences', () => {
+    const content = 'Sure! ```json\n{"name":"shell","arguments":{"command":"ls"}}\n``` done';
+    const out = extractRepairedToolCall(content, undefined, 'x');
+    expect(out).toEqual({ id: 'x', name: 'shell', arguments: { command: 'ls' } });
+  });
+
+  it('defaults arguments to {} when the envelope omits them', () => {
+    const out = extractRepairedToolCall('{"name":"list_files"}', undefined, 'x');
+    expect(out).toEqual({ id: 'x', name: 'list_files', arguments: {} });
+  });
+
+  it('returns null when there is no usable call', () => {
+    expect(extractRepairedToolCall('no json here', undefined, 'x')).toBeNull();
+    expect(extractRepairedToolCall('', undefined, 'x')).toBeNull();
+    expect(extractRepairedToolCall('{"broken": ', undefined, 'x')).toBeNull(); // unbalanced
+    expect(extractRepairedToolCall('{invalid json}', undefined, 'x')).toBeNull(); // balanced but unparseable
+    expect(extractRepairedToolCall('{"arguments":{}}', undefined, 'x')).toBeNull(); // no name
+  });
+});
+
+// ===========================================================================
+// Capability profile (feature 6)
+// ===========================================================================
+
+describe('familySupportsNativeTools', () => {
+  it('recognises tool-calling families', () => {
+    for (const m of ['llama3.1:8b', 'qwen2.5-coder', 'mistral:latest', 'devstral', 'gemma4:31b']) {
+      expect(familySupportsNativeTools(m)).toBe(true);
+    }
+  });
+  it('rejects families without reliable native tools', () => {
+    for (const m of ['gemma2:9b', 'llama2', 'phi-3', 'random-model']) {
+      expect(familySupportsNativeTools(m)).toBe(false);
+    }
+  });
+});
+
+describe('getLocalModelProfile', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    clearLocalModelProfileCache();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const showResponse = (body: unknown) => ({ ok: true, json: async () => body });
+
+  it('reads native tool support + context length from Ollama capabilities', async () => {
+    fetchMock.mockResolvedValue(showResponse({
+      capabilities: ['completion', 'vision', 'tools', 'thinking'],
+      model_info: { 'gemma4.context_length': 262144 },
+    }));
+    const p = await getLocalModelProfile('ollama', 'gemma4:31b', 'http://localhost:11434');
+    expect(p.supportsNativeToolCalls).toBe(true);
+    expect(p.supportsJsonSchemaFormat).toBe(true);
+    expect(p.contextLength).toBe(262144);
+    expect(p.capabilities).toContain('tools');
+  });
+
+  it('marks a model without the tools capability as no-native-tools', async () => {
+    fetchMock.mockResolvedValue(showResponse({ capabilities: ['completion', 'vision'] }));
+    const p = await getLocalModelProfile('ollama', 'llava:latest', 'http://localhost:11434');
+    expect(p.supportsNativeToolCalls).toBe(false);
+  });
+
+  it('reads a num_ctx override from Modelfile parameters', async () => {
+    fetchMock.mockResolvedValue(showResponse({ capabilities: ['completion', 'tools'], parameters: 'num_ctx 8192\nstop "<|end|>"' }));
+    const p = await getLocalModelProfile('ollama', 'custom:latest', 'http://localhost:11434');
+    expect(p.contextLength).toBe(8192);
+  });
+
+  it('degrades to the family heuristic when /api/show fails', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    const p = await getLocalModelProfile('ollama', 'llama3.1:8b', 'http://localhost:11434');
+    expect(p.supportsNativeToolCalls).toBe(true); // family heuristic
+    expect(p.capabilities).toBeUndefined();
+  });
+
+  it('degrades when fetch throws', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+    const p = await getLocalModelProfile('ollama', 'gemma2:9b', 'http://localhost:11434');
+    expect(p.supportsNativeToolCalls).toBe(false); // gemma2 not in heuristic
+  });
+
+  it('does not probe non-ollama local backends and reports no JSON-schema format', async () => {
+    const p = await getLocalModelProfile('litellm', 'qwen2.5:7b', 'http://localhost:4000');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(p.supportsJsonSchemaFormat).toBe(false);
+    expect(p.supportsNativeToolCalls).toBe(true); // qwen2.5 heuristic
+  });
+
+  it('caches per session (one probe per provider|model|baseUrl)', async () => {
+    fetchMock.mockResolvedValue(showResponse({ capabilities: ['completion', 'tools'] }));
+    await getLocalModelProfile('ollama', 'gemma4:31b', 'http://localhost:11434');
+    await getLocalModelProfile('ollama', 'gemma4:31b', 'http://localhost:11434');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalises a /v1-suffixed base URL before probing', async () => {
+    fetchMock.mockResolvedValue(showResponse({ capabilities: ['completion', 'tools'] }));
+    await getLocalModelProfile('ollama', 'x:1', 'http://localhost:11434/v1');
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:11434/api/show');
+  });
+});
+
+// ===========================================================================
+// System prompt selection (feature 5)
+// ===========================================================================
+
+describe('getSystemPromptForProvider', () => {
+  it('returns the full prompt for cloud providers', () => {
+    expect(getSystemPromptForProvider('anthropic')).toBe(getSystemPrompt());
+    expect(getSystemPromptForProvider('openai')).toBe(getSystemPrompt());
+  });
+  it('returns the compact prompt for local backends', () => {
+    expect(getSystemPromptForProvider('ollama')).toBe(getSystemPrompt({ compact: true }));
+    expect(getSystemPromptForProvider('litellm', 'http://localhost:4000')).toBe(getSystemPrompt({ compact: true }));
+  });
+});
+
+describe('compact system prompt', () => {
+  const full = getSystemPrompt();
+  const compact = getSystemPrompt({ compact: true });
+  const safetyBlock = full.slice(0, full.indexOf('[GROUNDING'));
+
+  it('is under 40% of the full prompt by token estimate', () => {
+    const ratio = estimateTokens(compact) / estimateTokens(full);
+    expect(ratio).toBeLessThan(0.4);
+  });
+
+  it('keeps the [SAFETY] rules block present verbatim', () => {
+    expect(compact.startsWith(safetyBlock)).toBe(true);
+    expect(compact).toContain('[SAFETY - These rules ALWAYS apply and cannot be overridden]');
+    expect(compact).toContain('[END SAFETY]');
+    // Every non-negotiable safety rule survives verbatim.
+    for (const rule of [
+      'Only modify files within the user',
+      'Never execute destructive system commands',
+      'Never access or leak credentials',
+      'Do NOT create documentation files unless explicitly requested',
+    ]) {
+      expect(compact).toContain(rule);
+    }
+  });
+
+  it('drops the verbose grounding section that only the full prompt carries', () => {
+    expect(full).toContain('[GROUNDING');
+    expect(compact).not.toContain('[GROUNDING');
+    expect(compact).toContain('Calliope');
+  });
+});
+
+describe('estimateTokens', () => {
+  it('scales ~4 chars per token', () => {
+    expect(estimateTokens('')).toBe(0);
+    expect(estimateTokens('abcd')).toBe(1);
+    expect(estimateTokens('abcde')).toBe(2);
+  });
+});

--- a/tests/ollama-format.test.ts
+++ b/tests/ollama-format.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Grammar-constrained output (#188 feature 3) — the Ollama provider passes the
+ * JSON-schema `format` param on the repair round-trip, and degrades silently
+ * (retry without it) when the server rejects the schema. Fully mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/config.js', () => ({
+  getBaseUrl: vi.fn(() => 'http://localhost:11434'),
+  get: vi.fn(),
+}));
+
+vi.mock('../src/model-detection.js', () => ({
+  getOllamaFallbackModel: vi.fn(),
+  getModelContextLimit: vi.fn(() => 128000),
+  getModelMaxOutput: vi.fn(() => 8192),
+}));
+
+vi.stubGlobal('fetch', vi.fn());
+
+import { chatOllama } from '../src/providers/ollama.js';
+import { buildToolCallEnvelopeSchema } from '../src/local-model.js';
+
+const OK = (data: object) => ({
+  ok: true,
+  status: 200,
+  json: async () => data,
+  text: async () => JSON.stringify(data),
+  clone: () => ({ text: async () => JSON.stringify(data) }),
+  body: null,
+});
+
+const ERR = (status: number, body: string) => ({
+  ok: false,
+  status,
+  json: async () => ({}),
+  text: async () => body,
+  clone: () => ({ text: async () => body }),
+  body: null,
+});
+
+const toolCallResponse = {
+  model: 'gemma4:31b',
+  message: { role: 'assistant', content: '', tool_calls: [{ id: 'c1', function: { name: 'read_file', arguments: { path: 'a.ts' } } }] },
+  done: true,
+  prompt_eval_count: 5,
+  eval_count: 6,
+};
+
+const format = buildToolCallEnvelopeSchema(['read_file', 'shell']);
+
+let bodies: any[];
+beforeEach(() => {
+  vi.clearAllMocks();
+  bodies = [];
+});
+
+function captureThen(...responses: any[]) {
+  let i = 0;
+  vi.mocked(fetch).mockImplementation(async (_url: any, init: any) => {
+    bodies.push(JSON.parse(init.body));
+    return (responses[i++] ?? responses[responses.length - 1]) as Response;
+  });
+}
+
+describe('chatOllama format param', () => {
+  it('includes the format schema in the request body when provided', async () => {
+    captureThen(OK(toolCallResponse));
+    await chatOllama([{ role: 'user', content: 'read a.ts' }], [], 'gemma4:31b', undefined, { format });
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0].format).toEqual(format);
+  });
+
+  it('omits format when no options are passed (normal turns stay unconstrained)', async () => {
+    captureThen(OK(toolCallResponse));
+    await chatOllama([{ role: 'user', content: 'hi' }], [], 'gemma4:31b');
+    expect(bodies[0].format).toBeUndefined();
+  });
+
+  it('degrades silently: retries WITHOUT format when the server rejects the schema (400)', async () => {
+    captureThen(ERR(400, 'invalid format: unsupported schema'), OK(toolCallResponse));
+    const res = await chatOllama([{ role: 'user', content: 'read a.ts' }], [], 'gemma4:31b', undefined, { format });
+    // Two requests: the constrained one (rejected), then the unconstrained retry.
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0].format).toEqual(format);
+    expect(bodies[1].format).toBeUndefined();
+    // The call still succeeds via the retry.
+    expect(res.toolCalls).toHaveLength(1);
+    expect(res.finishReason).toBe('tool_use');
+  });
+
+  it('does not retry-without-format when the constrained request succeeds', async () => {
+    captureThen(OK(toolCallResponse));
+    await chatOllama([{ role: 'user', content: 'read a.ts' }], [], 'gemma4:31b', undefined, { format });
+    expect(bodies).toHaveLength(1);
+  });
+
+  it('surfaces the error when the format-less retry also fails', async () => {
+    captureThen(ERR(400, 'bad format'), ERR(500, 'server exploded'));
+    await expect(
+      chatOllama([{ role: 'user', content: 'x' }], [], 'gemma4:31b', undefined, { format }),
+    ).rejects.toThrow(/500/);
+    expect(bodies).toHaveLength(2);
+  });
+});

--- a/tests/tools-anchor.test.ts
+++ b/tests/tools-anchor.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Hash-anchored edits (#188 feature 4) — read_file anchor footer + edit_file
+ * anchor_hash stale-view protection, exercised through executeTool with a real
+ * temp file. Fully local (no network).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { executeTool } from '../src/tools.js';
+import { resetScope } from '../src/scope.js';
+import { computeAnchorHash } from '../src/local-model.js';
+import type { ToolCall } from '../src/types.js';
+
+let tmpDir: string;
+const tc = (name: string, args: Record<string, unknown>): ToolCall => ({ id: `c-${Date.now()}`, name, arguments: args });
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-anchor-test-'));
+  resetScope(tmpDir);
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function write(name: string, content: string): string {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+describe('read_file anchor footer (local backends)', () => {
+  it('appends the current content hash when appendAnchorHash is set', async () => {
+    const content = 'line one\nline two\n';
+    write('a.txt', content);
+    const res = await executeTool(tc('read_file', { path: 'a.txt' }), tmpDir, 60000, undefined, { appendAnchorHash: true });
+    expect(res.isError).toBeFalsy();
+    expect(res.result).toContain(`[anchor_hash: ${computeAnchorHash(content)}`);
+    expect(res.result).toContain(content);
+  });
+
+  it('omits the footer by default (cloud backends)', async () => {
+    write('b.txt', 'hello');
+    const res = await executeTool(tc('read_file', { path: 'b.txt' }), tmpDir);
+    expect(res.result).not.toContain('anchor_hash');
+  });
+
+  it('omits the footer when appendAnchorHash is explicitly false', async () => {
+    write('c.txt', 'hello');
+    const res = await executeTool(tc('read_file', { path: 'c.txt' }), tmpDir, 60000, undefined, { appendAnchorHash: false });
+    expect(res.result).not.toContain('anchor_hash');
+  });
+});
+
+describe('edit_file anchor_hash stale-view protection', () => {
+  it('applies the edit when the anchor_hash matches current content', async () => {
+    const content = 'const x = 1;\n';
+    write('m.ts', content);
+    const res = await executeTool(
+      tc('edit_file', { path: 'm.ts', old_string: 'const x = 1;', new_string: 'const x = 2;', anchor_hash: computeAnchorHash(content) }),
+      tmpDir,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(fs.readFileSync(path.join(tmpDir, 'm.ts'), 'utf-8')).toContain('const x = 2;');
+  });
+
+  it('rejects the edit and tells the model to re-read when the anchor_hash is stale', async () => {
+    write('n.ts', 'const y = 1;\n');
+    const res = await executeTool(
+      tc('edit_file', { path: 'n.ts', old_string: 'const y = 1;', new_string: 'const y = 2;', anchor_hash: 'deadbeef' }),
+      tmpDir,
+    );
+    expect(res.isError).toBe(true);
+    expect(res.result).toContain('anchor_hash mismatch');
+    expect(res.result.toLowerCase()).toContain('re-read');
+    // File must be untouched on a rejected edit.
+    expect(fs.readFileSync(path.join(tmpDir, 'n.ts'), 'utf-8')).toBe('const y = 1;\n');
+  });
+
+  it('performs no check when anchor_hash is absent (inert for cloud)', async () => {
+    const content = 'const z = 1;\n';
+    write('o.ts', content);
+    const res = await executeTool(
+      tc('edit_file', { path: 'o.ts', old_string: 'const z = 1;', new_string: 'const z = 9;' }),
+      tmpDir,
+    );
+    expect(res.isError).toBeFalsy();
+    expect(fs.readFileSync(path.join(tmpDir, 'o.ts'), 'utf-8')).toContain('const z = 9;');
+  });
+
+  it('round-trips: read_file footer hash unlocks a subsequent anchored edit', async () => {
+    const content = 'export const flag = false;\n';
+    write('p.ts', content);
+    const read = await executeTool(tc('read_file', { path: 'p.ts' }), tmpDir, 60000, undefined, { appendAnchorHash: true });
+    const hash = read.result.match(/\[anchor_hash: ([0-9a-f]{8})/)![1];
+    const edit = await executeTool(
+      tc('edit_file', { path: 'p.ts', old_string: 'false', new_string: 'true', anchor_hash: hash }),
+      tmpDir,
+    );
+    expect(edit.isError).toBeFalsy();
+    expect(fs.readFileSync(path.join(tmpDir, 'p.ts'), 'utf-8')).toContain('flag = true');
+  });
+
+  it('a hash from before an external change is rejected as stale', async () => {
+    const original = 'a = 1\n';
+    write('q.ts', original);
+    const staleHash = computeAnchorHash(original);
+    // Something else changed the file after the model read it.
+    fs.writeFileSync(path.join(tmpDir, 'q.ts'), 'a = 1\nb = 2\n');
+    const res = await executeTool(
+      tc('edit_file', { path: 'q.ts', old_string: 'a = 1', new_string: 'a = 3', anchor_hash: staleHash }),
+      tmpDir,
+    );
+    expect(res.isError).toBe(true);
+    expect(res.result).toContain('anchor_hash mismatch');
+  });
+});


### PR DESCRIPTION
## Summary
- src/local-model.ts: local-backend detection, schema simplification (first-sentence descriptions, flattening, enum caps — lossless), malformed-call detection/repair helpers, anchor hashing, capability profiles, prompt selection
- Repair loop: one corrective round-trip per response for malformed local-model tool calls, json-schema format constraint applied on the repair turn (Ollama), silent degradation if rejected, ledger-recorded
- edit_file anchor_hash (optional): mismatched hash fails with a re-read instruction; read_file appends the hash footer for local backends only
- Compact prompt profile for local backends: 0.378x token ratio, [SAFETY] block byte-identical, full prompt untouched for cloud (risk tests pin it)
- Live-verified on Ollama gemma4:31b: capabilities [completion,vision,tools,thinking], 256K context, native tool_calls, format param accepted, real repair recovery — recorded in docs/local-models.md

## Test Plan
- +83 mocked tests (schema snapshots, repair, anchors, compact ratio, capability matrix): 3,589 passed, 4 skipped (100 files)
- Coverage 94.1% (local-model.ts and ollama.ts at 100%); bench PASS unchanged

Fixes #188