### PR TITLE
Add governance primitives: audit run logs, replay, budgets, policy hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ coming with the v3.0.0 stable release — see
 - **Built for models you run yourself.** Ollama and self-hosted OpenAI-compatible servers are first-class targets, not checkboxes. Run fully air-gapped.
 - **Sandbox-first execution.** Shell and code tools run inside macOS Seatbelt or Docker sandboxes (`auto`/`native`/`docker`/`off`). Blocklists are advisory; the sandbox is the boundary.
 - **Safety rails that survive long sessions.** Circuit breakers, iteration budgets, git-based checkpoints with `/restore`, and automatic context compaction.
+- **Governance built in.** Tamper-evident audit run logs (on by default), a `replay` command to inspect and verify them, budget caps that halt a run before it overspends, and a pre-tool policy hook for an external allow/deny engine. See [docs/governance.md](docs/governance.md).
 - **Small on purpose.** 22 commands. 16 config keys. 11 flags. v3 removed more code than it kept — the changelog lists everything that went and why.
 - **Tested like infrastructure.** 3,500 tests, 93%+ line coverage with an enforced 90% floor.
 
@@ -76,7 +77,7 @@ Drop a `CALLIOPE.md` in your repo and every session starts knowing your conventi
 
 v3 is a deliberate reduction: 84 commands, 40 config keys, and ~20k lines of speculative features (theme packs, companions, multi-agent orchestration, an embedded API server, and more) were removed to make the core fast, predictable, and maintainable. The full list and rationale live in [CHANGELOG.md](CHANGELOG.md) and the [v3.0 roadmap](https://github.com/calliopeai/calliope-cli/issues/195).
 
-Coming in v3.0 stable: single-binary installs (brew/curl, no Node required) and enforced performance budgets. Coming after: local-model edit-reliability hardening and governance primitives — replayable run logs, budget caps, audit trails.
+Coming in v3.0 stable: single-binary installs (brew/curl, no Node required) and enforced performance budgets. Governance primitives — replayable audit run logs, budget caps, and a policy hook — have landed; see [docs/governance.md](docs/governance.md). Coming after: local-model edit-reliability hardening.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ provider backends, and a small, tested command surface.
 - [Providers](./providers.md) — supported backends and how credentials resolve
 - [Local models](./local-models.md) — how the harness adapts to self-hosted 7-70B models
 - [Features](./features.md) — the full v3 feature set (and what was removed)
+- [Governance](./governance.md) — audit run logs, replay, budget caps, policy hook
 - [Fleet mode](./fleet.md) — optional multi-agent coordination over IRC
 
 ## Quick reference
@@ -30,6 +31,7 @@ provider backends, and a small, tested command surface.
 | `/cost` | Show spend this session |
 | `/clear` | Clear the conversation |
 | `/exit` | Quit (alias `/quit`) |
+| `calliope replay <path\|id>` | Render an audit run-log trace (see [governance](./governance.md)) |
 
 ### Keyboard shortcuts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,9 @@ There are 16 keys. Defaults are the values applied when a key is absent.
 | `sandboxMode` | string | `auto` | Code/shell sandbox: `auto`, `native`, `docker`, or `off`. |
 | `routing` | object | *(unset)* | `{ "enabled": boolean, "costSensitivity": 0-1 }`. Smart model routing (costSensitivity `0` = best quality, `1` = cheapest). |
 | `sessionLogLimit` | number | `0` | Cap retained session-log items (`0` = unlimited; range 0-100000). |
+| `audit` | object | *(on)* | Audit run log: `{ "enabled": boolean, "dir": string, "retention": number }`. On by default. See [Governance](./governance.md#audit-run-logs). |
+| `budget` | object | *(unset)* | Spend caps: `{ "maxCostPerRun": usd, "maxTokensPerRun": n, "maxCostPerProject": usd }`. See [Governance](./governance.md#budget-caps). |
+| `policy` | object | *(unset)* | Pre-tool policy hook: `{ "command": string, "timeoutMs": number }`. See [Governance](./governance.md#policy-hook). |
 
 ### Runtime changes with `/config set`
 
@@ -49,6 +52,10 @@ There are 16 keys. Defaults are the values applied when a key is absent.
 /config set routing.enabled true
 /config set routing.costSensitivity 0.3
 /config set theme light
+/config set budget.maxCostPerRun 0.50
+/config set budget.maxCostPerProject 20
+/config set audit.enabled false
+/config set policy.command /usr/local/bin/calliope-policy
 ```
 
 The remaining keys (`setupComplete`, `defaultProvider`, `defaultModel`,

--- a/docs/features.md
+++ b/docs/features.md
@@ -129,6 +129,16 @@ calliope --headless "fix the failing lint rule"
 echo "summarize the recent changes" | calliope --headless --json
 ```
 
+## Governance
+
+For agent-in-CI and enterprise use: a tamper-evident **audit run log** (on by
+default) at `~/.calliope-cli/runs/<sessionId>.jsonl`, a `calliope replay
+<path|sessionId>` command to render and verify it, **budget caps**
+(`budget.maxCostPerRun`, `budget.maxTokensPerRun`, `budget.maxCostPerProject`)
+that halt a run cleanly before it overspends (headless exit code 3), and a
+pre-tool **policy hook** (`policy.command`) for an external allow/deny engine.
+See [Governance](./governance.md).
+
 ## Fleet mode
 
 Optional agent-to-agent and operator-to-agent coordination over a shared IRC

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,260 @@
+# Governance
+
+Primitives for running Calliope as an agent in CI and in enterprise settings:
+an append-only **audit run log** with tamper evidence, a read-only **replay**
+command, **budget caps** that halt a run before it overspends, and a pre-tool
+**policy hook** for an external allow/deny engine.
+
+All four are local and dependency-free. The audit log is on by default; the rest
+are opt-in via config.
+
+- [Audit run logs](#audit-run-logs)
+- [Replay](#replay)
+- [Budget caps](#budget-caps)
+- [Policy hook](#policy-hook)
+- [Exit codes](#exit-codes)
+
+---
+
+## Audit run logs
+
+Every agent session writes an append-only JSONL trace to:
+
+```
+~/.calliope-cli/runs/<sessionId>.jsonl
+```
+
+One line per event. A session file may contain several *runs* (one per agent
+turn), each bracketed by `run_start` … `run_end`. Writes are buffered and
+appended asynchronously, so logging never blocks the agent loop.
+
+### Configuration
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `audit.enabled` | `true` | Master switch. It's on by default — the audit trail is the point, and it's cheap local disk. |
+| `audit.dir` | `~/.calliope-cli/runs` | Directory for run-log files. |
+| `audit.retention` | `100` | Keep the most recent N run-log files; older ones are pruned when a new session opens. |
+
+```bash
+calliope /config set audit.enabled false      # disable
+```
+
+Credentials are **never** written. The `run_start` config snapshot and every
+`tool_call`'s arguments pass through a redaction pass that strips values under
+secret-named keys (`apiKey`, `token`, `secret`, `password`, …) and masks
+secret-looking strings (`sk-…`, `AKIA…`, `ghp_…`, `Bearer …`, PEM blocks).
+
+### Schema (version 1)
+
+Every line carries a schema `v`ersion, a monotonic `seq`, an ISO `ts`, an event
+`type`, a type-specific payload, and the two hash-chain fields:
+
+```jsonc
+{
+  "v": 1,
+  "seq": 3,
+  "ts": "2026-07-05T21:14:08.164Z",
+  "type": "tool_call",
+  "id": "tc1",
+  "name": "shell",
+  "args": { "command": "ls -la" },
+  "prev_hash": "9f2c…",   // hash of the previous line
+  "hash": "1a7b…"         // sha256(prev_hash + canonical(this line without the chain fields))
+}
+```
+
+Event types and their payloads:
+
+| `type` | Payload |
+|--------|---------|
+| `run_start` | `session`, `cwd`, `provider`, `model`, `config` (redacted snapshot) |
+| `user_prompt` | `text` |
+| `assistant_message` | `content`, `tokens: {input, output}`, `cost` |
+| `tool_call` | `id`, `name`, `args` (redacted) |
+| `tool_result` | `id`, `result` (truncated), `isError`, `durationMs` |
+| `budget_event` | `scope` (`run`\|`project`), `kind` (`cost`\|`tokens`), `spent`, `cap`, `message` |
+| `policy_event` | `tool`, `decision` (`allow`\|`deny`), `source`, `reason?`, `durationMs` |
+| `run_end` | `totals: {inputTokens, outputTokens, cost, toolCalls, durationMs}`, `exitReason` |
+
+The schema is stable: fields are only ever added, and the `v` field is bumped
+for any breaking change.
+
+### Hash chain (tamper evidence)
+
+Each line's `hash` is `sha256(prev_hash + canonicalJSON(line-without-chain-fields))`,
+where the canonical form sorts object keys recursively so it is independent of
+key order. `prev_hash` is the previous line's `hash` (empty string for the first
+line). This forms a chain: **any** edit, reordering, insertion, or deletion
+changes a `hash` and breaks the link at that point. No signing keys are needed —
+this proves *integrity*, not authorship.
+
+Verify a trace with [`replay`](#replay); it recomputes the chain and reports
+either `Hash chain: OK` or `Hash chain: BROKEN at line N`.
+
+---
+
+## Replay
+
+Render a trace read-only to stdout — chronological, human-readable, with tool
+call/result pairing, running cost, and the chain-verification result:
+
+```bash
+calliope replay <path|sessionId>          # human-readable text
+calliope replay <sessionId> --json        # machine-readable (events + verification + summary)
+```
+
+A bare session id is resolved under `audit.dir`; a path is used as-is.
+
+```
+$ calliope replay session_1751749200_ab12
+Run log — 7 events
+────────────────────────────────────────────────────────────
+[21:14:08] ▶ run start  session=session_1751749200_ab12
+         cwd=/work/repo
+         provider=anthropic model=claude-sonnet-4-6
+[21:14:08] › user: list files then summarize
+[21:14:08] ‹ assistant [40→12 tok] $0.0012: Running ls
+[21:14:08]   ⚙ shell({"command":"ls -la"})  #tc1
+[21:14:08]   ✓ shell #tc1 (14ms): total 4 file.txt
+[21:14:08] ■ run end  reason=completed
+         tokens=95→18 cost=$0.0030 tools=1 duration=60ms
+────────────────────────────────────────────────────────────
+Cumulative assistant cost: $0.0030
+Hash chain: OK
+```
+
+**Exit codes:** `0` ok · `4` hash chain broken · `1` trace not found / unreadable.
+This makes `replay` usable as a CI integrity gate:
+
+```bash
+calliope replay "$SESSION_ID" >/dev/null || echo "audit trail failed verification"
+```
+
+---
+
+## Budget caps
+
+Halt a run before it overspends. Any cap left unset is not enforced.
+
+| Key | Unit | Scope |
+|-----|------|-------|
+| `budget.maxCostPerRun` | USD | A single agent run |
+| `budget.maxTokensPerRun` | input+output tokens | A single agent run |
+| `budget.maxCostPerProject` | USD | Accumulated across every run in a project directory |
+
+```bash
+calliope /config set budget.maxCostPerRun 0.50
+calliope /config set budget.maxCostPerProject 20
+calliope /config set budget.maxCostPerRun off      # clear a cap
+```
+
+Enforcement lives in the agent loop and the headless runner, right where cost
+and tokens are tallied after each provider response. When a cap is reached the
+agent **finishes the current tool result**, emits a `budget_event`, prints a
+one-line `spent vs cap` summary, and halts cleanly. Interactive sessions show
+the summary and stop the turn; `/status` shows budget state whenever any cap is
+configured.
+
+Per-project spend is tracked in a small ledger at
+`~/.calliope-cli/projects/<hash>/budget.json`, keyed by a hash of the resolved
+project path so it never lands inside your repo. It is only maintained when
+`budget.maxCostPerProject` is set.
+
+### CI recipe
+
+Headless runs exit **3** when a budget cap halts them — distinct from `1`
+(error) and `0` (success), so CI can react precisely:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CALLIOPE_PROVIDER=anthropic
+# Caps can be set once in config, or per-invocation via `calliope /config set`.
+
+calliope --headless "run the tests and fix any lint" 
+code=$?
+
+case "$code" in
+  0) echo "done within budget" ;;
+  3) echo "halted: budget cap reached (see the run log)"; exit 3 ;;
+  *) echo "agent error ($code)"; exit "$code" ;;
+esac
+```
+
+The run log records exactly why it stopped (`run_end` with `exitReason: budget`
+plus the preceding `budget_event`); replay it for the audit trail.
+
+---
+
+## Policy hook
+
+A pre-tool-call gate for an external allow/deny engine. This is a distinct,
+stronger-contract seam from the general [hooks](./configuration.md) (which veto
+via exit code 42 and pass context through environment variables): a policy
+engine receives the full tool-call JSON and uses conventional exit semantics.
+
+```bash
+calliope /config set policy.command /usr/local/bin/calliope-policy
+calliope /config set policy.command off    # disable
+```
+
+### Contract
+
+Before each tool executes, if `policy.command` is set, Calliope spawns it and:
+
+- **stdin** — the pending tool call as JSON: `{ "id": "...", "name": "...", "arguments": { ... } }`
+- **exit 0** — ALLOW; the tool runs.
+- **exit non-zero** — DENY; the tool is skipped and the agent sees
+  `[Denied by policy: <stderr>]` as the tool result. `stderr` is the reason.
+- **timeout** (`policy.timeoutMs`, default 5000ms) — DENY (**fail closed**).
+- **spawn failure** (command missing, etc.) — DENY (**fail closed**).
+
+Every decision is recorded as a `policy_event` in the run log. Failing closed is
+deliberate: a broken or unreachable policy engine must not silently wave tools
+through.
+
+### Shell example
+
+A minimal policy that blocks writes outside `/work` and denies `rm -rf`:
+
+```bash
+#!/usr/bin/env bash
+# /usr/local/bin/calliope-policy — reads a tool call on stdin.
+call="$(cat)"
+name="$(printf '%s' "$call" | jq -r '.name')"
+cmd="$(printf '%s' "$call"  | jq -r '.arguments.command // empty')"
+path="$(printf '%s' "$call" | jq -r '.arguments.path // empty')"
+
+if printf '%s' "$cmd" | grep -Eq 'rm[[:space:]]+-rf'; then
+  echo "destructive command blocked" >&2
+  exit 1
+fi
+if [ -n "$path" ] && [ "${path#/work}" = "$path" ]; then
+  echo "writes are restricted to /work" >&2
+  exit 1
+fi
+exit 0   # allow
+```
+
+### Zentinelle integration
+
+This seam is the integration point for [Zentinelle](https://github.com/calliopeai)
+policy enforcement. Point `policy.command` at the Zentinelle adapter: it reads
+the tool-call JSON on stdin, evaluates it against the active policy set, and
+returns `0` (allow) or non-zero with a reason on stderr (deny). Because the
+contract is just *JSON in, exit code out*, any engine that speaks it — Zentinelle,
+OPA/Rego wrapped in a shell shim, or a bespoke script — plugs in without code
+changes to Calliope.
+
+---
+
+## Exit codes
+
+| Code | Where | Meaning |
+|------|-------|---------|
+| `0` | headless / replay | success / trace verified ok |
+| `1` | headless / replay | error / trace not found or unreadable |
+| `3` | headless | halted by a budget cap |
+| `4` | replay | hash chain broken |

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -154,6 +154,16 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
+  // Handle `replay` subcommand — render a run-log trace read-only to stdout.
+  // Runs before setup/config gates: replaying an audit trail needs no provider.
+  if (args[0] === 'replay') {
+    const { runReplay } = await import('./replay.js');
+    // First non-flag arg after `replay` is the path or session id.
+    const target = args.slice(1).find((a) => !a.startsWith('-'));
+    const code = runReplay(target, { json: args.includes('--json') });
+    process.exit(code);
+  }
+
   // Handle --upgrade
   if (args.includes('--upgrade') || args.includes('-u')) {
     const current = getVersion();
@@ -292,6 +302,7 @@ ${bold('calliope')} - Multi-model AI agent CLI
 
 ${bold('USAGE')}
   calliope [options] [prompt]
+  calliope replay <path|sessionId> [--json]   Render an audit run-log trace
 
 ${bold('OPTIONS')}
   -h, --help        Show this help message

--- a/src/budget.ts
+++ b/src/budget.ts
@@ -1,0 +1,195 @@
+/**
+ * Calliope CLI - Budget Caps (#189)
+ *
+ * Spend guardrails for agent-in-CI and enterprise use. Three optional caps:
+ *   - budget.maxCostPerRun   (USD, per agent run)
+ *   - budget.maxTokensPerRun (input+output tokens, per agent run)
+ *   - budget.maxCostPerProject (USD, accumulated across runs in a project dir)
+ *
+ * Per-run caps are checked against totals the caller accumulates during a single
+ * run. The per-project cap is checked against a small ledger file under
+ * `~/.calliope-cli/projects/<hash>/budget.json`, keyed by a hash of the resolved
+ * project path so it never lands inside the user's repo.
+ *
+ * When a cap is exceeded the agent loop finishes the current tool result, emits a
+ * `budget_event` to the run log, and halts cleanly (headless exit code 3).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createHash } from 'crypto';
+import * as config from './config.js';
+
+export interface BudgetCaps {
+  maxCostPerRun?: number;
+  maxTokensPerRun?: number;
+  maxCostPerProject?: number;
+}
+
+export interface BudgetUsage {
+  /** USD spent so far in the current run. */
+  runCostUsd: number;
+  /** input+output tokens so far in the current run. */
+  runTokens: number;
+  /** USD spent across all runs in this project (including the current run). */
+  projectCostUsd: number;
+}
+
+export interface BudgetVerdict {
+  exceeded: boolean;
+  scope?: 'run' | 'project';
+  kind?: 'cost' | 'tokens';
+  spent?: number;
+  cap?: number;
+  message?: string;
+}
+
+export interface ProjectSpend {
+  spentUsd: number;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Config
+// ============================================================================
+
+/** Read the configured budget caps (empty object when none set). */
+export function getBudgetCaps(): BudgetCaps {
+  try {
+    return (config.get('budget') as BudgetCaps | undefined) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/** True if any cap is set (used to skip work / show state entirely). */
+export function hasBudgetCaps(caps: BudgetCaps): boolean {
+  return (
+    typeof caps.maxCostPerRun === 'number' ||
+    typeof caps.maxTokensPerRun === 'number' ||
+    typeof caps.maxCostPerProject === 'number'
+  );
+}
+
+// ============================================================================
+// Per-project spend ledger
+// ============================================================================
+
+const PROJECTS_DIR = path.join(os.homedir(), '.calliope-cli', 'projects');
+
+/** Stable per-project key: first 16 hex of sha256 of the resolved path. */
+export function projectKey(projectDir: string): string {
+  let resolved = projectDir;
+  try {
+    resolved = fs.realpathSync(projectDir);
+  } catch {
+    resolved = path.resolve(projectDir);
+  }
+  return createHash('sha256').update(resolved).digest('hex').slice(0, 16);
+}
+
+export function projectBudgetPath(projectDir: string): string {
+  return path.join(PROJECTS_DIR, projectKey(projectDir), 'budget.json');
+}
+
+export function loadProjectSpend(projectDir: string): ProjectSpend {
+  const file = projectBudgetPath(projectDir);
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as Partial<ProjectSpend>;
+    const spentUsd = typeof parsed.spentUsd === 'number' && parsed.spentUsd >= 0 ? parsed.spentUsd : 0;
+    return { spentUsd, updatedAt: parsed.updatedAt ?? new Date(0).toISOString() };
+  } catch {
+    return { spentUsd: 0, updatedAt: new Date(0).toISOString() };
+  }
+}
+
+/**
+ * Add `costUsd` to the project's accumulated spend and persist it atomically.
+ * Returns the new total. A zero/negative delta is a no-op read.
+ */
+export function recordProjectSpend(projectDir: string, costUsd: number): number {
+  const current = loadProjectSpend(projectDir);
+  if (!(costUsd > 0)) return current.spentUsd;
+
+  const next: ProjectSpend = {
+    spentUsd: current.spentUsd + costUsd,
+    updatedAt: new Date().toISOString(),
+  };
+  const file = projectBudgetPath(projectDir);
+  const dir = path.dirname(file);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2));
+    fs.renameSync(tmp, file);
+  } catch {
+    // Persistence is best-effort; enforcement still uses the in-memory total.
+  }
+  return next.spentUsd;
+}
+
+/** Reset a project's accumulated spend (used by tooling/tests). */
+export function resetProjectSpend(projectDir: string): void {
+  const file = projectBudgetPath(projectDir);
+  try {
+    fs.unlinkSync(file);
+  } catch {
+    /* nothing to reset */
+  }
+}
+
+// ============================================================================
+// Evaluation
+// ============================================================================
+
+/**
+ * Evaluate caps against current usage. Returns the first cap exceeded (run cost,
+ * then run tokens, then project cost). `exceeded: false` when within budget.
+ */
+export function evaluateBudget(caps: BudgetCaps, usage: BudgetUsage): BudgetVerdict {
+  if (typeof caps.maxCostPerRun === 'number' && usage.runCostUsd >= caps.maxCostPerRun) {
+    return {
+      exceeded: true,
+      scope: 'run',
+      kind: 'cost',
+      spent: usage.runCostUsd,
+      cap: caps.maxCostPerRun,
+      message: `Run cost cap reached: $${usage.runCostUsd.toFixed(4)} >= $${caps.maxCostPerRun.toFixed(2)} cap`,
+    };
+  }
+  if (typeof caps.maxTokensPerRun === 'number' && usage.runTokens >= caps.maxTokensPerRun) {
+    return {
+      exceeded: true,
+      scope: 'run',
+      kind: 'tokens',
+      spent: usage.runTokens,
+      cap: caps.maxTokensPerRun,
+      message: `Run token cap reached: ${usage.runTokens} >= ${caps.maxTokensPerRun} cap`,
+    };
+  }
+  if (typeof caps.maxCostPerProject === 'number' && usage.projectCostUsd >= caps.maxCostPerProject) {
+    return {
+      exceeded: true,
+      scope: 'project',
+      kind: 'cost',
+      spent: usage.projectCostUsd,
+      cap: caps.maxCostPerProject,
+      message: `Project cost cap reached: $${usage.projectCostUsd.toFixed(4)} >= $${caps.maxCostPerProject.toFixed(2)} cap`,
+    };
+  }
+  return { exceeded: false };
+}
+
+/** One-line halt summary for the user/CI log. */
+export function formatBudgetHalt(verdict: BudgetVerdict): string {
+  if (!verdict.exceeded) return '';
+  const unit = verdict.kind === 'tokens' ? '' : '$';
+  const spent = verdict.kind === 'tokens'
+    ? String(verdict.spent ?? 0)
+    : (verdict.spent ?? 0).toFixed(4);
+  const cap = verdict.kind === 'tokens'
+    ? String(verdict.cap ?? 0)
+    : (verdict.cap ?? 0).toFixed(2);
+  return `Budget cap reached (${verdict.scope} ${verdict.kind}): spent ${unit}${spent} of ${unit}${cap}. Halting.`;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,26 @@ export interface CalliopeConfig {
 
   // Session Lifecycle
   sessionLogLimit: number;    // Cap retained ledger entries/runs/failures per session (0 = unlimited)
+
+  // Governance (#189) — audit trail, budget caps, policy hook.
+  // Audit run logs are ON by default (local disk, cheap; the audit trail is the point).
+  audit?: {
+    enabled?: boolean;   // default true
+    dir?: string;        // override for the run-log directory (default ~/.calliope-cli/runs)
+    retention?: number;  // keep the most recent N run-log files (default 100)
+  };
+  // Spend caps. Any cap left undefined is not enforced.
+  budget?: {
+    maxCostPerRun?: number;      // USD, per agent run
+    maxTokensPerRun?: number;    // input+output tokens, per agent run
+    maxCostPerProject?: number;  // USD, accumulated across runs in a project dir
+  };
+  // Pre-tool policy hook. `command` receives the tool-call JSON on stdin;
+  // exit 0 = allow, non-zero = deny (stderr = reason), timeout = deny (fail closed).
+  policy?: {
+    command?: string;
+    timeoutMs?: number;  // default 5000
+  };
 }
 
 const DEFAULT_CONFIG: CalliopeConfig = {
@@ -101,6 +121,9 @@ const config = new Conf<CalliopeConfig>({
     sandboxMode: { type: 'string', enum: ['auto', 'native', 'docker', 'off'] },
     routing: { type: 'object' },
     sessionLogLimit: { type: 'number', minimum: 0, maximum: 100000 },
+    audit: { type: 'object' },
+    budget: { type: 'object' },
+    policy: { type: 'object' },
   },
 });
 
@@ -354,6 +377,8 @@ const SURVIVOR_KEYS = new Set<string>([
   'maxIterations', 'maxIterationTime', 'autoSaveHistory', 'autoUpgrade',
   'collapseTools', 'toolDisplayLimit', 'diffStyle', 'circuitBreakersEnabled',
   'sandboxMode', 'routing', 'sessionLogLimit',
+  // Governance (#189)
+  'audit', 'budget', 'policy',
 ]);
 
 /**

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -9,10 +9,16 @@
 import * as config from './config.js';
 import { chat, selectProvider } from './providers/index.js';
 import { TOOLS, executeTool, getTools } from './tools.js';
-import { DEFAULT_MODELS } from './types.js';
+import { DEFAULT_MODELS, calculateCost } from './types.js';
 import { getSystemPromptForProvider, isLocalBackend } from './local-model.js';
 import * as memory from './memory.js';
 import { resolveIterationLimit } from './iteration-limit.js';
+import { RunLog } from './runlog.js';
+import {
+  getBudgetCaps, evaluateBudget, hasBudgetCaps,
+  recordProjectSpend, loadProjectSpend, formatBudgetHalt,
+} from './budget.js';
+import { evaluatePolicy, isPolicyEnabled } from './policy.js';
 import type { Message, LLMProvider, ToolCall } from './types.js';
 
 // ============================================================================
@@ -195,13 +201,87 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
     },
   }, outputMode);
 
+  // ---- Governance (#189): audit run log, budget caps, policy hook ----------
+  const sessionId = `session_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const runlog = RunLog.open(sessionId);
+  const costModel = model || DEFAULT_MODELS[resolvedProvider];
+  const budgetCaps = getBudgetCaps();
+  // Only maintain the cross-run project ledger when a project cap is active.
+  const trackProjectBudget = typeof budgetCaps.maxCostPerProject === 'number';
+  const runStartedAt = Date.now();
+  let runInputTokens = 0;
+  let runOutputTokens = 0;
+  let runCostUsd = 0;
+  let runToolCalls = 0;
+
+  runlog.runStart({
+    session: sessionId,
+    cwd,
+    provider: resolvedProvider,
+    model: costModel,
+    config: config.getConfig() as unknown as Record<string, unknown>,
+  });
+  runlog.userPrompt(prompt);
+  if (runlog.enabled) {
+    emit({ type: 'status', timestamp: now(), data: { message: `Run log: ${runlog.filePath}` } }, outputMode);
+  }
+
+  const runTotals = () => ({
+    inputTokens: runInputTokens,
+    outputTokens: runOutputTokens,
+    cost: runCostUsd,
+    toolCalls: runToolCalls,
+    durationMs: Date.now() - runStartedAt,
+  });
+
   try {
     let iteration = 0;
+    let budgetVerdict: ReturnType<typeof evaluateBudget> | undefined;
 
-    while (iteration < maxIterations) {
+    // Up-front project-budget guard: refuse to start a run whose project has
+    // already spent its cap (the CI hard stop) before making any provider call.
+    if (hasBudgetCaps(budgetCaps)) {
+      const pre = evaluateBudget(budgetCaps, {
+        runCostUsd: 0,
+        runTokens: 0,
+        projectCostUsd: loadProjectSpend(cwd).spentUsd,
+      });
+      if (pre.exceeded) budgetVerdict = pre;
+    }
+
+    while (!budgetVerdict && iteration < maxIterations) {
       iteration++;
 
       const response = await chat(provider, messages, TOOLS, model);
+
+      // Accumulate spend, persist it to the project ledger, and audit it.
+      if (response.usage) {
+        const usageCost = calculateCost(costModel, response.usage.inputTokens, response.usage.outputTokens);
+        runInputTokens += response.usage.inputTokens;
+        runOutputTokens += response.usage.outputTokens;
+        runCostUsd += usageCost;
+        if (trackProjectBudget) recordProjectSpend(cwd, usageCost);
+        runlog.assistantMessage({
+          content: response.content,
+          tokens: { input: response.usage.inputTokens, output: response.usage.outputTokens },
+          cost: usageCost,
+        });
+      } else {
+        runlog.assistantMessage({ content: response.content, tokens: { input: 0, output: 0 }, cost: 0 });
+      }
+
+      // Budget check: finish the current turn cleanly if a cap is now exceeded.
+      if (hasBudgetCaps(budgetCaps)) {
+        const verdict = evaluateBudget(budgetCaps, {
+          runCostUsd,
+          runTokens: runInputTokens + runOutputTokens,
+          projectCostUsd: loadProjectSpend(cwd).spentUsd,
+        });
+        if (verdict.exceeded) {
+          budgetVerdict = verdict;
+          break;
+        }
+      }
 
       if (response.toolCalls && response.toolCalls.length > 0) {
         // Add assistant message with tool calls
@@ -221,10 +301,37 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
               arguments: toolCall.arguments,
             },
           }, outputMode);
+          runlog.toolCall({ id: toolCall.id, name: toolCall.name, args: toolCall.arguments as Record<string, unknown> });
+          runToolCalls++;
+
+          // Pre-tool policy gate (fail closed). A deny short-circuits execution;
+          // the agent sees the denial as the tool result and can adapt.
+          if (isPolicyEnabled()) {
+            const verdict = await evaluatePolicy(toolCall);
+            runlog.policyEvent({
+              tool: toolCall.name,
+              decision: verdict.decision,
+              source: verdict.source,
+              reason: verdict.reason,
+              durationMs: verdict.durationMs,
+            });
+            if (verdict.decision === 'deny') {
+              const denyText = `[Policy denied: ${verdict.reason || 'no reason given'}]`;
+              runlog.toolResult({ id: toolCall.id, result: denyText, isError: true, durationMs: verdict.durationMs });
+              emit({
+                type: 'tool_result',
+                timestamp: now(),
+                data: { toolCallId: toolCall.id, name: toolCall.name, result: denyText, isError: true },
+              }, outputMode);
+              messages.push({ role: 'tool', content: denyText, toolCallId: toolCall.id });
+              continue;
+            }
+          }
 
           // Execute tool with a guarded retry budget.
           // Only retry classified-transient errors, never re-run mutating tools
           // (avoids duplicated side effects), and back off between attempts.
+          const toolStart = Date.now();
           let result = await executeTool(toolCall, cwd, 60000, undefined, { appendAnchorHash: localBackend });
           let attempt = 0;
           while (
@@ -249,6 +356,12 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
               isError: result.isError || false,
             },
           }, outputMode);
+          runlog.toolResult({
+            id: toolCall.id,
+            result: result.result,
+            isError: result.isError || false,
+            durationMs: Date.now() - toolStart,
+          });
 
           messages.push({
             role: 'tool',
@@ -278,12 +391,31 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
       break;
     }
 
+    // Budget halt: emit the event, summarize spend vs cap, exit code 3.
+    if (budgetVerdict?.exceeded) {
+      const summary = formatBudgetHalt(budgetVerdict);
+      runlog.budgetEvent({
+        scope: budgetVerdict.scope ?? 'run',
+        kind: budgetVerdict.kind ?? 'cost',
+        spent: budgetVerdict.spent ?? 0,
+        cap: budgetVerdict.cap ?? 0,
+        message: budgetVerdict.message ?? summary,
+      });
+      emit({ type: 'status', timestamp: now(), data: { message: summary } }, outputMode);
+      process.stderr.write(summary + '\n');
+      runlog.runEnd({ totals: runTotals(), exitReason: 'budget' });
+      await runlog.flush();
+      return 3;
+    }
+
     emit({
       type: 'done',
       timestamp: now(),
       data: { iterations: iteration },
     }, outputMode);
 
+    runlog.runEnd({ totals: runTotals(), exitReason: 'completed' });
+    await runlog.flush();
     return 0;
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
@@ -292,6 +424,8 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
       timestamp: now(),
       data: { message: msg },
     }, outputMode);
+    runlog.runEnd({ totals: runTotals(), exitReason: 'error' });
+    await runlog.flush();
     return 1;
   }
 }

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,0 +1,164 @@
+/**
+ * Calliope CLI - Policy Hook (#189)
+ *
+ * A pre-tool-call governance seam distinct from the general `hooks.ts` plumbing.
+ * The built-in hooks already veto via exit code 42 and pass context through
+ * environment variables; a policy *engine* wants the full tool-call JSON and
+ * conventional exit semantics. So `policy.command` gets a stronger, purpose-built
+ * contract:
+ *
+ *   - stdin:  JSON `{ id, name, arguments }` for the pending tool call
+ *   - exit 0: ALLOW
+ *   - exit non-zero: DENY, with stderr used as the human-readable reason
+ *   - timeout (default 5s) or spawn failure: DENY (fail closed)
+ *
+ * This is the Zentinelle integration point — see docs/governance.md. Every
+ * decision is surfaced to the caller so it can be logged as a `policy_event`.
+ */
+
+import { spawn } from 'child_process';
+import * as config from './config.js';
+import type { ToolCall } from './types.js';
+
+export type PolicyDecision = 'allow' | 'deny';
+
+export interface PolicyResult {
+  decision: PolicyDecision;
+  /** 'none' when no policy is configured; 'policy' when the command ran/decided. */
+  source: 'none' | 'policy';
+  reason?: string;
+  durationMs: number;
+}
+
+export interface PolicyOptions {
+  /** Override the configured command (tests / embedding). */
+  command?: string;
+  /** Override the configured timeout in ms. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/** Configured policy command, or undefined when policy enforcement is off. */
+export function getPolicyCommand(): string | undefined {
+  try {
+    const policy = config.get('policy') as { command?: string } | undefined;
+    const cmd = policy?.command;
+    return typeof cmd === 'string' && cmd.trim().length > 0 ? cmd : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getPolicyTimeout(): number {
+  try {
+    const policy = config.get('policy') as { timeoutMs?: number } | undefined;
+    const t = policy?.timeoutMs;
+    return typeof t === 'number' && t > 0 ? t : DEFAULT_TIMEOUT_MS;
+  } catch {
+    return DEFAULT_TIMEOUT_MS;
+  }
+}
+
+/** True when a policy command is configured (or explicitly provided). */
+export function isPolicyEnabled(options: PolicyOptions = {}): boolean {
+  return Boolean(options.command ?? getPolicyCommand());
+}
+
+/**
+ * Evaluate the policy command for a pending tool call. Always resolves (never
+ * rejects): any failure to run the command is treated as a DENY so a broken or
+ * unreachable policy engine cannot silently wave tools through.
+ */
+export function evaluatePolicy(toolCall: ToolCall, options: PolicyOptions = {}): Promise<PolicyResult> {
+  const command = options.command ?? getPolicyCommand();
+  const started = Date.now();
+
+  if (!command) {
+    return Promise.resolve({ decision: 'allow', source: 'none', durationMs: 0 });
+  }
+
+  const timeoutMs = options.timeoutMs ?? getPolicyTimeout();
+  const input = JSON.stringify({
+    id: toolCall.id,
+    name: toolCall.name,
+    arguments: toolCall.arguments,
+  });
+
+  return new Promise<PolicyResult>((resolve) => {
+    let settled = false;
+    const done = (result: Omit<PolicyResult, 'durationMs'>): void => {
+      if (settled) return;
+      settled = true;
+      resolve({ ...result, durationMs: Date.now() - started });
+    };
+
+    // `detached` runs the command in its own process group so the timeout can
+    // kill the whole group, not just the shell.
+    let proc: ReturnType<typeof spawn>;
+    try {
+      proc = spawn('sh', ['-c', command], { stdio: ['pipe', 'pipe', 'pipe'], detached: true });
+    } catch (err) {
+      // Fail closed: if we cannot even launch the policy, deny.
+      done({ decision: 'deny', source: 'policy', reason: `policy spawn failed: ${err instanceof Error ? err.message : String(err)}` });
+      return;
+    }
+
+    let stderr = '';
+    let timedOut = false;
+
+    proc.stderr?.on('data', (d) => {
+      stderr += d.toString();
+    });
+
+    const signalGroup = (signal: NodeJS.Signals): void => {
+      try {
+        if (proc.pid !== undefined) process.kill(-proc.pid, signal);
+      } catch {
+        try {
+          proc.kill(signal);
+        } catch {
+          /* already dead */
+        }
+      }
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      signalGroup('SIGTERM');
+      setTimeout(() => signalGroup('SIGKILL'), 2000);
+    }, timeoutMs);
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        // Fail closed on timeout.
+        done({ decision: 'deny', source: 'policy', reason: `policy hook timed out after ${timeoutMs}ms (fail closed)` });
+        return;
+      }
+      if (code === 0) {
+        done({ decision: 'allow', source: 'policy' });
+      } else {
+        done({
+          decision: 'deny',
+          source: 'policy',
+          reason: stderr.trim() || `policy denied (exit ${code ?? 'unknown'})`,
+        });
+      }
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      // Fail closed on runtime spawn error (e.g. command not found).
+      done({ decision: 'deny', source: 'policy', reason: `policy hook error: ${err.message}` });
+    });
+
+    // Feed the tool-call JSON to the policy on stdin, then close it.
+    try {
+      proc.stdin?.write(input);
+      proc.stdin?.end();
+    } catch {
+      /* if stdin is gone the process will exit on its own; close/error handles it */
+    }
+  });
+}

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -1,0 +1,192 @@
+/**
+ * Calliope CLI - Replay (#189)
+ *
+ * `calliope replay <path|sessionId>` renders a run-log trace read-only to stdout:
+ * chronological, human-readable, per-event timestamps, tool call/result pairing,
+ * running cost accumulation, and a hash-chain verification result at the end.
+ * `--json` emits the parsed events plus the verification for machine consumption.
+ *
+ * Exit codes: 0 = ok, 4 = hash chain broken, 1 = trace not found / unreadable.
+ * Plain text only (no Ink), like the headless renderer.
+ */
+
+import * as fs from 'fs';
+import {
+  readRunLog,
+  verifyChain,
+  runLogPath,
+  resolveAuditSettings,
+  type RunLogLine,
+  type ChainVerification,
+} from './runlog.js';
+
+export interface ReplayOptions {
+  json?: boolean;
+  /** Injectable writers (tests); default to process streams. */
+  stdout?: (s: string) => void;
+  stderr?: (s: string) => void;
+}
+
+/**
+ * Resolve a replay target to a file path. Accepts either a direct path to a
+ * `.jsonl` trace or a bare session id (resolved under the audit dir). Returns
+ * null when nothing matches.
+ */
+export function resolveReplayTarget(pathOrSessionId: string): string | null {
+  if (fs.existsSync(pathOrSessionId) && fs.statSync(pathOrSessionId).isFile()) {
+    return pathOrSessionId;
+  }
+  const { dir } = resolveAuditSettings();
+  const candidate = runLogPath(pathOrSessionId, dir);
+  if (fs.existsSync(candidate)) return candidate;
+  return null;
+}
+
+function shortTime(ts: string): string {
+  // Render the time portion; fall back to the raw value if it isn't ISO.
+  const m = /T(\d{2}:\d{2}:\d{2})/.exec(ts);
+  return m ? m[1] : ts;
+}
+
+function preview(text: string, max = 200): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  return oneLine.length > max ? oneLine.slice(0, max) + '…' : oneLine;
+}
+
+function compactArgs(args: Record<string, unknown>): string {
+  const s = JSON.stringify(args);
+  return s.length > 160 ? s.slice(0, 160) + '…' : s;
+}
+
+/**
+ * Render a trace as human-readable text. Pure: returns the full string so it can
+ * be asserted in tests or written to any stream.
+ */
+export function renderReplay(lines: RunLogLine[], verification: ChainVerification): string {
+  const out: string[] = [];
+  // Map tool-call id -> name for pairing results back to their calls.
+  const toolNames = new Map<string, string>();
+  let cumulativeCost = 0;
+
+  out.push(`Run log — ${lines.length} event${lines.length === 1 ? '' : 's'}`);
+  out.push('─'.repeat(60));
+
+  for (const line of lines) {
+    const t = shortTime(line.ts);
+    switch (line.type) {
+      case 'run_start': {
+        const p = line as unknown as { session: string; cwd: string; provider: string; model: string };
+        out.push(`[${t}] ▶ run start  session=${p.session}`);
+        out.push(`         cwd=${p.cwd}`);
+        out.push(`         provider=${p.provider} model=${p.model}`);
+        break;
+      }
+      case 'user_prompt': {
+        out.push(`[${t}] › user: ${preview(String((line as { text?: unknown }).text ?? ''))}`);
+        break;
+      }
+      case 'assistant_message': {
+        const p = line as unknown as { content: string; tokens?: { input: number; output: number }; cost?: number };
+        cumulativeCost += p.cost ?? 0;
+        const tok = p.tokens ? ` [${p.tokens.input}→${p.tokens.output} tok]` : '';
+        const cost = typeof p.cost === 'number' ? ` $${p.cost.toFixed(4)}` : '';
+        out.push(`[${t}] ‹ assistant${tok}${cost}: ${preview(String(p.content ?? ''))}`);
+        break;
+      }
+      case 'tool_call': {
+        const p = line as unknown as { id: string; name: string; args: Record<string, unknown> };
+        toolNames.set(p.id, p.name);
+        out.push(`[${t}]   ⚙ ${p.name}(${compactArgs(p.args ?? {})})  #${p.id}`);
+        break;
+      }
+      case 'tool_result': {
+        const p = line as unknown as { id: string; result: string; isError: boolean; durationMs: number };
+        const name = toolNames.get(p.id) ?? '?';
+        const flag = p.isError ? '✗' : '✓';
+        out.push(`[${t}]   ${flag} ${name} #${p.id} (${p.durationMs}ms): ${preview(String(p.result ?? ''), 160)}`);
+        break;
+      }
+      case 'budget_event': {
+        const p = line as unknown as { message: string };
+        out.push(`[${t}] ‖ budget: ${p.message}`);
+        break;
+      }
+      case 'policy_event': {
+        const p = line as unknown as { tool: string; decision: string; reason?: string };
+        const reason = p.reason ? ` — ${p.reason}` : '';
+        out.push(`[${t}] ⛨ policy: ${p.decision.toUpperCase()} ${p.tool}${reason}`);
+        break;
+      }
+      case 'run_end': {
+        const p = line as unknown as { totals: { inputTokens: number; outputTokens: number; cost: number; toolCalls: number; durationMs: number }; exitReason: string };
+        const tt = p.totals;
+        out.push(`[${t}] ■ run end  reason=${p.exitReason}`);
+        out.push(`         tokens=${tt.inputTokens}→${tt.outputTokens} cost=$${tt.cost.toFixed(4)} tools=${tt.toolCalls} duration=${tt.durationMs}ms`);
+        break;
+      }
+      default: {
+        out.push(`[${t}] ${line.type}`);
+      }
+    }
+  }
+
+  out.push('─'.repeat(60));
+  out.push(`Cumulative assistant cost: $${cumulativeCost.toFixed(4)}`);
+  if (verification.ok) {
+    out.push('Hash chain: OK');
+  } else {
+    out.push(`Hash chain: BROKEN at line ${verification.brokenAtLine} (${verification.reason})`);
+  }
+  return out.join('\n');
+}
+
+/** Machine-readable render: events, verification, and a small summary. */
+export function renderReplayJson(lines: RunLogLine[], verification: ChainVerification): string {
+  let cost = 0;
+  let toolCalls = 0;
+  for (const line of lines) {
+    if (line.type === 'assistant_message') cost += (line as { cost?: number }).cost ?? 0;
+    if (line.type === 'tool_call') toolCalls += 1;
+  }
+  return JSON.stringify({
+    events: lines,
+    verification,
+    summary: { eventCount: lines.length, cumulativeCost: cost, toolCalls },
+  });
+}
+
+/**
+ * CLI entry: resolve the target, verify, render, and return an exit code.
+ * 0 = ok, 4 = chain broken, 1 = not found / unreadable.
+ */
+export function runReplay(pathOrSessionId: string | undefined, options: ReplayOptions = {}): number {
+  const write = options.stdout ?? ((s: string) => process.stdout.write(s));
+  const writeErr = options.stderr ?? ((s: string) => process.stderr.write(s));
+
+  if (!pathOrSessionId) {
+    writeErr('replay: missing <path|sessionId>\nUsage: calliope replay <path|sessionId> [--json]\n');
+    return 1;
+  }
+
+  const filePath = resolveReplayTarget(pathOrSessionId);
+  if (!filePath) {
+    writeErr(`replay: run log not found: ${pathOrSessionId}\n`);
+    return 1;
+  }
+
+  let lines: RunLogLine[];
+  try {
+    lines = readRunLog(filePath);
+  } catch (err) {
+    writeErr(`replay: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+
+  const verification = verifyChain(lines);
+  const rendered = options.json
+    ? renderReplayJson(lines, verification)
+    : renderReplay(lines, verification);
+  write(rendered + '\n');
+
+  return verification.ok ? 0 : 4;
+}

--- a/src/runlog.ts
+++ b/src/runlog.ts
@@ -1,0 +1,489 @@
+/**
+ * Calliope CLI - Run Logs (audit trail)
+ *
+ * Append-only JSONL trace of an agent session, written to
+ * `~/.calliope-cli/runs/<sessionId>.jsonl` (override with `audit.dir`).
+ *
+ * Every line is a self-describing event carrying a schema `v`ersion, a monotonic
+ * `seq`uence number, an ISO `ts`, the event `type`, a type-specific payload, and
+ * a tamper-evidence hash chain: `prev_hash` (the previous line's hash) and `hash`
+ * (sha256 of `prev_hash` + the canonical JSON of the line body). No signing keys
+ * are needed — any edit, reorder, insertion, or deletion breaks the chain at that
+ * line, which `verifyChain` reports. See docs/governance.md.
+ *
+ * Writes are buffered and appended asynchronously (ordered via an internal
+ * promise chain); fsync is not forced per line, so logging never blocks the agent
+ * loop. The hash chain is advanced synchronously so ordering is always correct.
+ *
+ * On by default: the audit trail is the point, and it is local disk. Disable with
+ * `audit.enabled = false`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createHash } from 'crypto';
+import * as config from './config.js';
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+/** Run-log schema version. Bump only for breaking payload changes. */
+export const RUNLOG_SCHEMA_VERSION = 1;
+
+export type RunLogEventType =
+  | 'run_start'
+  | 'user_prompt'
+  | 'assistant_message'
+  | 'tool_call'
+  | 'tool_result'
+  | 'budget_event'
+  | 'policy_event'
+  | 'run_end';
+
+/** The stable, on-disk shape of a run-log line. */
+export interface RunLogLine {
+  v: number;
+  seq: number;
+  ts: string;
+  type: RunLogEventType;
+  prev_hash: string;
+  hash: string;
+  // Type-specific payload fields are merged in at the top level.
+  [key: string]: unknown;
+}
+
+export interface RunStartPayload {
+  session: string;
+  cwd: string;
+  provider: string;
+  model: string;
+  /** Config snapshot with credentials stripped (never contains apiKey/token values). */
+  config: Record<string, unknown>;
+}
+
+export interface AssistantMessagePayload {
+  content: string;
+  tokens: { input: number; output: number };
+  cost: number;
+}
+
+export interface ToolCallPayload {
+  id: string;
+  name: string;
+  /** Arguments after a redaction pass for obvious secrets. */
+  args: Record<string, unknown>;
+}
+
+export interface ToolResultPayload {
+  id: string;
+  result: string;
+  isError: boolean;
+  durationMs: number;
+}
+
+export interface BudgetEventPayload {
+  scope: 'run' | 'project';
+  kind: 'cost' | 'tokens';
+  spent: number;
+  cap: number;
+  message: string;
+}
+
+export interface PolicyEventPayload {
+  tool: string;
+  decision: 'allow' | 'deny';
+  source: string;
+  reason?: string;
+  durationMs: number;
+}
+
+export interface RunEndPayload {
+  totals: {
+    inputTokens: number;
+    outputTokens: number;
+    cost: number;
+    toolCalls: number;
+    durationMs: number;
+  };
+  exitReason: string;
+}
+
+// ============================================================================
+// Redaction
+// ============================================================================
+
+/** Object keys whose values are always credentials — stripped wholesale. */
+const SECRET_KEY_RE =
+  /(api[-_]?key|token|secret|password|passwd|authorization|credential|access[-_]?key|private[-_]?key|client[-_]?secret|session[-_]?token|bearer)/i;
+
+/** String values that look like well-known secret formats. */
+const SECRET_VALUE_PATTERNS: RegExp[] = [
+  /sk-ant-[A-Za-z0-9_-]{16,}/,
+  /sk-[A-Za-z0-9_-]{16,}/,
+  /AKIA[0-9A-Z]{16}/,
+  /gh[pousr]_[A-Za-z0-9]{16,}/,
+  /github_pat_[A-Za-z0-9_]{22,}/,
+  /xox[baprs]-[A-Za-z0-9-]{10,}/,
+  /\bBearer\s+[A-Za-z0-9._~+/-]{16,}=*/,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+];
+
+const REDACTED = '[REDACTED]';
+
+function redactString(value: string): string {
+  let out = value;
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    out = out.replace(new RegExp(pattern, 'g'), REDACTED);
+  }
+  return out;
+}
+
+/**
+ * Deep-copy `value`, replacing anything that looks like a secret with
+ * `[REDACTED]`. Keys matching {@link SECRET_KEY_RE} are stripped by key name
+ * (so an empty or oddly-formatted API key is still removed); string values
+ * matching a known secret format are masked in place. Structure is preserved so
+ * the trace stays readable and diffable.
+ */
+export function redactSecrets(value: unknown): unknown {
+  if (typeof value === 'string') return redactString(value);
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(redactSecrets);
+
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (SECRET_KEY_RE.test(key)) {
+      out[key] = REDACTED;
+    } else {
+      out[key] = redactSecrets(val);
+    }
+  }
+  return out;
+}
+
+// ============================================================================
+// Hash chain
+// ============================================================================
+
+/**
+ * Deterministic JSON with object keys sorted recursively, so a line's canonical
+ * form is independent of key insertion order. Arrays keep their order.
+ */
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value ?? null);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalize).join(',') + ']';
+  }
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  const parts = keys.map(
+    (k) => JSON.stringify(k) + ':' + canonicalize((value as Record<string, unknown>)[k]),
+  );
+  return '{' + parts.join(',') + '}';
+}
+
+function hashBody(prevHash: string, body: Record<string, unknown>): string {
+  return createHash('sha256').update(prevHash + canonicalize(body)).digest('hex');
+}
+
+export interface ChainVerification {
+  ok: boolean;
+  /** 1-based line number where the chain first breaks, if any. */
+  brokenAtLine?: number;
+  /** Human-readable reason for the break. */
+  reason?: string;
+}
+
+/**
+ * Recompute the hash chain over parsed lines and report the first break.
+ * A line breaks the chain if its `prev_hash` does not match the previous line's
+ * `hash`, or if its recomputed `hash` does not match its stored `hash`.
+ */
+export function verifyChain(lines: RunLogLine[]): ChainVerification {
+  let prev = '';
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Reconstruct the body (everything except the chain fields).
+    const { prev_hash, hash, ...body } = line;
+    if (prev_hash !== prev) {
+      return { ok: false, brokenAtLine: i + 1, reason: 'prev_hash mismatch' };
+    }
+    const expected = hashBody(prev_hash, body);
+    if (expected !== hash) {
+      return { ok: false, brokenAtLine: i + 1, reason: 'hash mismatch' };
+    }
+    prev = hash;
+  }
+  return { ok: true };
+}
+
+// ============================================================================
+// Paths + rotation
+// ============================================================================
+
+export interface AuditSettings {
+  enabled: boolean;
+  dir: string;
+  retention: number;
+}
+
+const DEFAULT_RUNS_DIR = path.join(os.homedir(), '.calliope-cli', 'runs');
+const DEFAULT_RETENTION = 100;
+
+/** Resolve audit settings from config, with optional explicit overrides. */
+export function resolveAuditSettings(overrides: Partial<AuditSettings> = {}): AuditSettings {
+  let stored: { enabled?: boolean; dir?: string; retention?: number } | undefined;
+  try {
+    stored = config.get('audit');
+  } catch {
+    stored = undefined;
+  }
+  const enabled =
+    overrides.enabled ?? stored?.enabled ?? true; // ON by default
+  const dir = overrides.dir ?? stored?.dir ?? DEFAULT_RUNS_DIR;
+  const retentionRaw = overrides.retention ?? stored?.retention ?? DEFAULT_RETENTION;
+  const retention = Number.isFinite(retentionRaw) && retentionRaw > 0
+    ? Math.floor(retentionRaw)
+    : DEFAULT_RETENTION;
+  return { enabled, dir, retention };
+}
+
+/** Return the run-log file path for a session id under the given (or default) dir. */
+export function runLogPath(sessionId: string, dir = DEFAULT_RUNS_DIR): string {
+  // Session ids are internally generated (`session_<ts>_<rand>`), but guard
+  // against path traversal from any externally-supplied id all the same.
+  const safe = sessionId.replace(/[^A-Za-z0-9_.-]/g, '_');
+  return path.join(dir, `${safe}.jsonl`);
+}
+
+/**
+ * Keep only the most recent `retention` run-log files in `dir` (by mtime),
+ * deleting the rest. Best-effort: a delete failure is ignored.
+ */
+export function rotateRuns(dir: string, retention: number): void {
+  if (retention <= 0) return;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir).filter((f) => f.endsWith('.jsonl'));
+  } catch {
+    return;
+  }
+  if (entries.length <= retention) return;
+
+  const withMtime = entries
+    .map((f) => {
+      const full = path.join(dir, f);
+      try {
+        return { full, mtime: fs.statSync(full).mtimeMs };
+      } catch {
+        return { full, mtime: 0 };
+      }
+    })
+    .sort((a, b) => b.mtime - a.mtime); // newest first
+
+  for (const { full } of withMtime.slice(retention)) {
+    try {
+      fs.unlinkSync(full);
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
+// ============================================================================
+// Reading
+// ============================================================================
+
+/**
+ * Parse a run-log file into lines. Blank lines are skipped; an unparseable line
+ * throws (a corrupt trace should be visible, not silently truncated). Callers
+ * that want tolerance can catch.
+ */
+export function readRunLog(filePath: string): RunLogLine[] {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const lines: RunLogLine[] = [];
+  const rawLines = content.split('\n');
+  for (let i = 0; i < rawLines.length; i++) {
+    const raw = rawLines[i].trim();
+    if (!raw) continue;
+    try {
+      lines.push(JSON.parse(raw) as RunLogLine);
+    } catch {
+      throw new Error(`runlog: unparseable JSON on line ${i + 1} of ${filePath}`);
+    }
+  }
+  return lines;
+}
+
+// ============================================================================
+// RunLog (writer)
+// ============================================================================
+
+/** Per-file instance cache so multiple turns share one hash chain. */
+const cache = new Map<string, RunLog>();
+
+export class RunLog {
+  readonly sessionId: string;
+  readonly filePath: string;
+  readonly enabled: boolean;
+  private seq = 0;
+  private prevHash = '';
+  private writeTail: Promise<void> = Promise.resolve();
+
+  private constructor(sessionId: string, filePath: string, enabled: boolean) {
+    this.sessionId = sessionId;
+    this.filePath = filePath;
+    this.enabled = enabled;
+  }
+
+  /**
+   * Open (or reuse) the run log for a session. If a trace already exists on disk
+   * the hash chain is resumed from its last valid line. Multiple opens for the
+   * same file return the same instance so a session's turns share one chain.
+   */
+  static open(sessionId: string, overrides: Partial<AuditSettings> = {}): RunLog {
+    const settings = resolveAuditSettings(overrides);
+    const filePath = runLogPath(sessionId, settings.dir);
+
+    const existing = cache.get(filePath);
+    if (existing) return existing;
+
+    const log = new RunLog(sessionId, filePath, settings.enabled);
+    if (settings.enabled) {
+      try {
+        fs.mkdirSync(settings.dir, { recursive: true });
+      } catch {
+        /* if the dir can't be made, writes below will no-op via the catch */
+      }
+      // Rotate old sessions before this new one lands (cheap: once per open).
+      if (!fs.existsSync(filePath)) {
+        rotateRuns(settings.dir, settings.retention);
+      } else {
+        log.resumeChain();
+      }
+    }
+    cache.set(filePath, log);
+    return log;
+  }
+
+  /** Resume seq/prev_hash from the last valid line of an existing trace. */
+  private resumeChain(): void {
+    let lines: RunLogLine[];
+    try {
+      lines = readRunLog(this.filePath);
+    } catch {
+      // Corrupt tail: fall back to a best-effort scan for the last valid line.
+      lines = [];
+      try {
+        const raw = fs.readFileSync(this.filePath, 'utf-8').split('\n');
+        for (const line of raw) {
+          const t = line.trim();
+          if (!t) continue;
+          try {
+            lines.push(JSON.parse(t) as RunLogLine);
+          } catch {
+            /* skip torn line */
+          }
+        }
+      } catch {
+        return;
+      }
+    }
+    const last = lines[lines.length - 1];
+    if (last && typeof last.hash === 'string' && typeof last.seq === 'number') {
+      this.prevHash = last.hash;
+      this.seq = last.seq + 1;
+    }
+  }
+
+  /** Build the next line, advance the chain synchronously, enqueue the write. */
+  private append(type: RunLogEventType, payload: Record<string, unknown>): void {
+    if (!this.enabled) return;
+    const body: Record<string, unknown> = {
+      v: RUNLOG_SCHEMA_VERSION,
+      seq: this.seq,
+      ts: new Date().toISOString(),
+      type,
+      ...payload,
+    };
+    const hash = hashBody(this.prevHash, body);
+    const line: RunLogLine = { ...(body as object), prev_hash: this.prevHash, hash } as RunLogLine;
+    this.prevHash = hash;
+    this.seq += 1;
+
+    const text = JSON.stringify(line) + '\n';
+    this.writeTail = this.writeTail
+      .then(() => fs.promises.appendFile(this.filePath, text))
+      .catch(() => {
+        /* logging must never throw into the agent loop; drop on I/O error */
+      });
+  }
+
+  runStart(payload: RunStartPayload): void {
+    this.append('run_start', {
+      ...payload,
+      config: redactSecrets(payload.config) as Record<string, unknown>,
+    });
+  }
+
+  userPrompt(text: string): void {
+    this.append('user_prompt', { text });
+  }
+
+  assistantMessage(payload: AssistantMessagePayload): void {
+    this.append('assistant_message', { ...payload });
+  }
+
+  toolCall(payload: ToolCallPayload): void {
+    this.append('tool_call', {
+      id: payload.id,
+      name: payload.name,
+      args: redactSecrets(payload.args) as Record<string, unknown>,
+    });
+  }
+
+  toolResult(payload: ToolResultPayload, maxResultChars = 2000): void {
+    const result = payload.result.length > maxResultChars
+      ? payload.result.slice(0, maxResultChars) + `\n... [truncated ${payload.result.length - maxResultChars} chars]`
+      : payload.result;
+    this.append('tool_result', {
+      id: payload.id,
+      result,
+      isError: payload.isError,
+      durationMs: payload.durationMs,
+    });
+  }
+
+  budgetEvent(payload: BudgetEventPayload): void {
+    this.append('budget_event', { ...payload });
+  }
+
+  policyEvent(payload: PolicyEventPayload): void {
+    this.append('policy_event', { ...payload });
+  }
+
+  runEnd(payload: RunEndPayload): void {
+    this.append('run_end', { ...payload });
+  }
+
+  /** Await all buffered writes. */
+  flush(): Promise<void> {
+    return this.writeTail;
+  }
+
+  /** Flush and drop this instance from the shared cache. */
+  async close(): Promise<void> {
+    await this.flush();
+    cache.delete(this.filePath);
+  }
+}
+
+/**
+ * Clear the in-memory instance cache (tests only). Does not touch disk.
+ */
+export function resetRunLogs(): void {
+  cache.clear();
+}

--- a/src/ui/agent.ts
+++ b/src/ui/agent.ts
@@ -47,6 +47,13 @@ import {
   formatIterationProgress,
   isFiniteIterationLimit,
 } from '../iteration-limit.js';
+import { RunLog } from '../runlog.js';
+import {
+  getBudgetCaps, evaluateBudget, hasBudgetCaps,
+  recordProjectSpend, loadProjectSpend, formatBudgetHalt,
+  type BudgetVerdict,
+} from '../budget.js';
+import { evaluatePolicy, isPolicyEnabled } from '../policy.js';
 
 // ============================================================================
 // Tool Result Truncation
@@ -335,6 +342,48 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
   const executeOptions = { appendAnchorHash: localBackend };
   const repairedCallIds = new Set<string>();
 
+  // Governance (#189): audit run log, budget caps, policy hook. The run log is a
+  // per-session append-only JSONL trace; each agent turn is one run within it.
+  const sessionId = ctx.sessionRef.current?.id ?? 'session_adhoc';
+  const projectDir = ctx.sessionRef.current?.projectPath ?? process.cwd();
+  const runlog = RunLog.open(sessionId);
+  const budgetCaps = getBudgetCaps();
+  // Only maintain the cross-run project ledger when a project cap is active.
+  const trackProjectBudget = typeof budgetCaps.maxCostPerProject === 'number';
+  const runStartedAt = Date.now();
+  let runInputTokens = 0;
+  let runOutputTokens = 0;
+  let runCostUsd = 0;
+  let runToolCalls = 0;
+  let runEnded = false;
+  let runExitReason: string | undefined;
+  let budgetVerdict: BudgetVerdict | undefined;
+
+  runlog.runStart({
+    session: sessionId,
+    cwd: projectDir,
+    provider: effectiveProvider,
+    model: effectiveModel || ctx.actualModel,
+    config: config.getConfig() as unknown as Record<string, unknown>,
+  });
+  runlog.userPrompt(summarizeMessageContent(content));
+
+  const finalizeRun = (exitReason: string): void => {
+    if (runEnded) return;
+    runEnded = true;
+    runlog.runEnd({
+      totals: {
+        inputTokens: runInputTokens,
+        outputTokens: runOutputTokens,
+        cost: runCostUsd,
+        toolCalls: runToolCalls,
+        durationMs: Date.now() - runStartedAt,
+      },
+      exitReason,
+    });
+    void runlog.flush();
+  };
+
   // Check context limit and warn if approaching capacity
   // Uses model's actual context length from API when available
   let currentContextTokens = ctx.estimateContextTokens();
@@ -483,6 +532,32 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
         }
       }
 
+      // Governance: accrue run spend, audit the assistant turn, evaluate budget.
+      {
+        const turnCost = response.usage
+          ? calculateCost(ctx.model || DEFAULT_MODELS[ctx.provider], response.usage.inputTokens, response.usage.outputTokens)
+          : 0;
+        if (response.usage) {
+          runInputTokens += response.usage.inputTokens;
+          runOutputTokens += response.usage.outputTokens;
+          runCostUsd += turnCost;
+          if (trackProjectBudget) recordProjectSpend(projectDir, turnCost);
+        }
+        runlog.assistantMessage({
+          content: response.content,
+          tokens: { input: response.usage?.inputTokens ?? 0, output: response.usage?.outputTokens ?? 0 },
+          cost: turnCost,
+        });
+        if (hasBudgetCaps(budgetCaps)) {
+          const verdict = evaluateBudget(budgetCaps, {
+            runCostUsd,
+            runTokens: runInputTokens + runOutputTokens,
+            projectCostUsd: loadProjectSpend(projectDir).spentUsd,
+          });
+          if (verdict.exceeded) budgetVerdict = verdict;
+        }
+      }
+
       // Circuit breaker check after each iteration
       if (ctx.circuitBreaker) {
         const iterData: IterationData = {
@@ -537,6 +612,8 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
 
         for (const toolCall of response.toolCalls) {
           const args = toolCall.arguments as Record<string, unknown>;
+          runlog.toolCall({ id: toolCall.id, name: toolCall.name, args });
+          runToolCalls++;
           const toolPreview = String(args.command || args.path || '...');
           const risk = assessToolRisk(toolCall);
           const riskConfig = RISK_CONFIG[risk.level];
@@ -577,9 +654,30 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
               ctx.addMessage('tool', `⚡ ${toolCall.name}: ${toolPreview}${riskDisplay}`);
               ctx.addMessage('tool', `🛑 Blocked by hook: ${preHookResult.reason}`);
             } else {
-              // Tool can be executed
-              executableTools.push(toolCall);
-              ctx.addMessage('tool', `⚡ ${toolCall.name}: ${toolPreview}${riskDisplay}`);
+              // Pre-tool policy gate (fail closed). Distinct from the hook above:
+              // the policy engine receives the tool-call JSON on stdin and denies
+              // via a non-zero exit code (see policy.ts / docs/governance.md).
+              const policyResult = isPolicyEnabled() ? await evaluatePolicy(toolCall) : undefined;
+              if (policyResult) {
+                runlog.policyEvent({
+                  tool: toolCall.name,
+                  decision: policyResult.decision,
+                  source: policyResult.source,
+                  reason: policyResult.reason,
+                  durationMs: policyResult.durationMs,
+                });
+              }
+              if (policyResult && policyResult.decision === 'deny') {
+                preCheck.blocked = true;
+                preCheck.blockReason = 'denied by policy';
+                preCheck.blockContent = `[Denied by policy: ${policyResult.reason || 'no reason given'}]`;
+                ctx.addMessage('tool', `⚡ ${toolCall.name}: ${toolPreview}${riskDisplay}`);
+                ctx.addMessage('tool', `⛨ Denied by policy: ${policyResult.reason || 'no reason given'}`);
+              } else {
+                // Tool can be executed
+                executableTools.push(toolCall);
+                ctx.addMessage('tool', `⚡ ${toolCall.name}: ${toolPreview}${riskDisplay}`);
+              }
             }
           }
 
@@ -588,6 +686,7 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
           // Record blocked tools in ledger and add to LLM messages
           if (preCheck.blocked) {
             ctx.ledger?.recordAction(toolCall.name, args, 'blocked', preCheck.blockReason);
+            runlog.toolResult({ id: toolCall.id, result: preCheck.blockContent!, isError: true, durationMs: 0 });
             ctx.llmMessages.current.push({
               role: 'tool',
               content: preCheck.blockContent!,
@@ -659,6 +758,8 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
                 failed ? 'error' : 'ok',
                 failed ? failureText : undefined,
               );
+              // Audit the tool result (parallel exec has no per-call duration).
+              runlog.toolResult({ id: toolCall.id, result: failed ? failureText : result.result, isError: failed, durationMs: 0 });
 
               // Execute post-tool hooks
               hooks.executeHooks('post-tool', {
@@ -748,6 +849,7 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
                   detail: chunk.trimEnd().split('\n').pop()?.substring(0, 60),
                 });
               } : undefined;
+              const seqStart = Date.now();
               const result = await executeTool(toolCall, ctx.sessionRef.current?.projectPath ?? process.cwd(), 60000, shellStreamCallback, executeOptions);
               ctx.debugLog('tools', 'DONE', toolCall.name);
 
@@ -758,6 +860,8 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
                 result.isError ? 'error' : 'ok',
                 result.isError ? result.result : undefined,
               );
+              // Audit the tool result.
+              runlog.toolResult({ id: toolCall.id, result: result.result, isError: result.isError || false, durationMs: Date.now() - seqStart });
 
               // Execute post-tool hooks
               hooks.executeHooks('post-tool', {
@@ -824,6 +928,24 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
           }
         }
         ctx.ledger?.endIteration();
+        // Budget halt: the current tool result is finished; stop before the next
+        // provider call. Record a budget_event and summarize spend vs cap.
+        if (budgetVerdict?.exceeded) {
+          const summary = formatBudgetHalt(budgetVerdict);
+          runlog.budgetEvent({
+            scope: budgetVerdict.scope ?? 'run',
+            kind: budgetVerdict.kind ?? 'cost',
+            spent: budgetVerdict.spent ?? 0,
+            cap: budgetVerdict.cap ?? 0,
+            message: budgetVerdict.message ?? summary,
+          });
+          ctx.addMessage('system', `‖ ${summary}`);
+          runStatus = 'stopped';
+          runErrorSummary = summary;
+          runExitReason = 'budget';
+          completedNaturally = true;
+          break;
+        }
         if (completedNaturally) break; // ask_question pauses for user input (#42)
         continue;
       }
@@ -851,6 +973,20 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
       }
       completedNaturally = true;
       runStatus = 'completed';
+      // The answer is already shown; if this final turn crossed a budget cap,
+      // still record it so the audit trail reflects why spend stopped here.
+      if (budgetVerdict?.exceeded) {
+        const summary = formatBudgetHalt(budgetVerdict);
+        runlog.budgetEvent({
+          scope: budgetVerdict.scope ?? 'run',
+          kind: budgetVerdict.kind ?? 'cost',
+          spent: budgetVerdict.spent ?? 0,
+          cap: budgetVerdict.cap ?? 0,
+          message: budgetVerdict.message ?? summary,
+        });
+        ctx.addMessage('system', `‖ ${summary}`);
+        runExitReason = 'budget';
+      }
 
       // End iteration ledger entry
       ctx.ledger?.endIteration('success');
@@ -931,6 +1067,7 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
       if (runId && runStatus) {
         ctx.ledger?.finishRun(runId, runStatus, { errorSummary: runErrorSummary });
       }
+      finalizeRun(runExitReason ?? runStatus ?? 'error');
       return; // Exit early on error - don't process queued messages
     }
   }
@@ -947,6 +1084,7 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
   if (runId) {
     ctx.ledger?.finishRun(runId, runStatus || 'completed', { errorSummary: runErrorSummary });
   }
+  finalizeRun(runExitReason ?? runStatus ?? 'completed');
 
   // Update context tokens after agent run
   ctx.setContextTokens(ctx.estimateContextTokens());

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -24,6 +24,7 @@ import { fleetConfigured, fleetActive, fleetStatus, fleetEnable, fleetDisable, f
 import { getTerminalImageInfo, getImageModeLabel } from '../terminal-image.js';
 import { resetContextWarnings } from './context.js';
 import * as memory from '../memory.js';
+import { getBudgetCaps, hasBudgetCaps, loadProjectSpend } from '../budget.js';
 import type { IterationLedger } from '../iteration-ledger.js';
 import {
   resolveIterationLimit,
@@ -140,6 +141,27 @@ function getActiveProjectDir(ctx: Pick<CommandContext, 'sessionRef'>): string {
 
 function formatSessionLogLimit(limit: number): string {
   return limit > 0 ? String(limit) : 'unlimited';
+}
+
+/**
+ * Apply a `budget.*` config key. `off`/`none`/empty clears the cap. Throws on an
+ * invalid number so the caller's try/catch surfaces the message.
+ */
+function applyBudgetKey(field: 'maxCostPerRun' | 'maxTokensPerRun' | 'maxCostPerProject', value: string): string {
+  const budget = { ...(config.get('budget') ?? {}) } as Record<string, number>;
+  if (value === 'off' || value === 'none' || value === '') {
+    delete budget[field];
+    config.set('budget', budget);
+    return `✓ ${field} cleared`;
+  }
+  const num = Number(value);
+  if (isNaN(num) || num < 0) {
+    throw new Error(`${field} must be a non-negative number (or 'off' to clear)`);
+  }
+  budget[field] = field === 'maxTokensPerRun' ? Math.floor(num) : num;
+  config.set('budget', budget);
+  const unit = field === 'maxTokensPerRun' ? ' tokens' : ' USD';
+  return `✓ ${field} set to ${budget[field]}${unit}`;
 }
 
 // ============================================================================
@@ -341,6 +363,19 @@ File references: @filename, ./path, /absolute/path`;
         statusMsg += `\nFleet: active (${fleetSt.nick}) | irc:${fleetSt.config?.ircAddr} | #${fleetSt.config?.channel}`;
       }
 
+      // Show budget state when any cap is configured.
+      const caps = getBudgetCaps();
+      if (hasBudgetCaps(caps)) {
+        const parts: string[] = [];
+        if (typeof caps.maxCostPerRun === 'number') parts.push(`run<=$${caps.maxCostPerRun}`);
+        if (typeof caps.maxTokensPerRun === 'number') parts.push(`run<=${caps.maxTokensPerRun}tok`);
+        if (typeof caps.maxCostPerProject === 'number') {
+          const spent = loadProjectSpend(getActiveProjectDir(ctx)).spentUsd;
+          parts.push(`project $${spent.toFixed(4)}/$${caps.maxCostPerProject}`);
+        }
+        statusMsg += `\nBudget: ${parts.join(' | ')}`;
+      }
+
       ctx.addMessage('system', statusMsg);
       break;
     }
@@ -425,7 +460,12 @@ Available keys:
   sandboxMode <auto|native|docker|off>    - Code execution sandbox
   routing.enabled <bool>                  - Smart model routing
   routing.costSensitivity <0-1>           - Cost vs quality (0 = best, 1 = cheapest)
-  theme <dark|light|no-color>             - Color theme`);
+  theme <dark|light|no-color>             - Color theme
+  budget.maxCostPerRun <usd|off>          - Halt a run at this spend (0/off = no cap)
+  budget.maxTokensPerRun <n|off>          - Halt a run at this token count
+  budget.maxCostPerProject <usd|off>      - Halt when project spend reaches this
+  audit.enabled <bool>                    - Audit run log (on by default)
+  policy.command <path|off>               - Pre-tool policy hook script`);
           break;
         }
 
@@ -494,6 +534,26 @@ Available keys:
               ctx.addMessage('system', `✓ theme set to ${value}`);
             } else {
               ctx.addMessage('error', `Theme not found: ${value}. Options: dark, light, no-color`);
+            }
+          } else if (key === 'budget.maxCostPerRun') {
+            ctx.addMessage('system', applyBudgetKey('maxCostPerRun', value));
+          } else if (key === 'budget.maxTokensPerRun') {
+            ctx.addMessage('system', applyBudgetKey('maxTokensPerRun', value));
+          } else if (key === 'budget.maxCostPerProject') {
+            ctx.addMessage('system', applyBudgetKey('maxCostPerProject', value));
+          } else if (key === 'audit.enabled') {
+            const bool = value === 'true';
+            config.set('audit', { ...(config.get('audit') ?? {}), enabled: bool });
+            ctx.addMessage('system', `✓ audit.enabled set to ${bool}`);
+          } else if (key === 'policy.command') {
+            const policy = { ...(config.get('policy') ?? {}) } as Record<string, unknown>;
+            if (value === 'off' || value === 'none') {
+              delete policy.command;
+              config.set('policy', policy);
+              ctx.addMessage('system', '✓ policy.command cleared');
+            } else {
+              config.set('policy', { ...policy, command: value });
+              ctx.addMessage('system', '✓ policy.command set');
             }
           } else {
             ctx.addMessage('error', `Unknown config key: ${key}`);

--- a/tests/agent-repair.test.ts
+++ b/tests/agent-repair.test.ts
@@ -20,7 +20,12 @@ const READ_FILE_TOOL: Tool = {
 
 vi.mock('../src/config.js', () => ({
   default: {},
-  get: vi.fn((key: string) => (key === 'maxIterations' ? 3 : undefined)),
+  get: vi.fn((key: string) => {
+    if (key === 'maxIterations') return 3;
+    if (key === 'audit') return { enabled: false }; // no run-log disk writes in tests
+    return undefined;
+  }),
+  getConfig: vi.fn(() => ({})),
   getBaseUrl: vi.fn(() => 'http://localhost:11434'),
 }));
 

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for src/budget.ts — spend caps and per-project accumulation.
+ *
+ * Covers: evaluateBudget for run cost, run tokens, and project cost; the
+ * per-project spend ledger (load/record/reset, atomic + resilient); cap
+ * presence detection; and the halt summary formatting.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const { tmpHome } = vi.hoisted(() => {
+  const _fs = require('fs') as typeof import('fs');
+  const _path = require('path') as typeof import('path');
+  const _os = require('os') as typeof import('os');
+  const dir = _fs.mkdtempSync(_path.join(_os.tmpdir(), 'calliope-budget-test-'));
+  return { tmpHome: dir };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpHome };
+});
+
+import {
+  evaluateBudget,
+  hasBudgetCaps,
+  loadProjectSpend,
+  recordProjectSpend,
+  resetProjectSpend,
+  projectBudgetPath,
+  formatBudgetHalt,
+  type BudgetCaps,
+} from '../src/budget.js';
+
+const PROJECT = tmpHome; // a real, resolvable dir so realpath works
+
+beforeEach(() => {
+  resetProjectSpend(PROJECT);
+});
+
+afterAll(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// hasBudgetCaps
+// ---------------------------------------------------------------------------
+
+describe('hasBudgetCaps', () => {
+  it('is false for an empty caps object', () => {
+    expect(hasBudgetCaps({})).toBe(false);
+  });
+  it('is true if any cap is set', () => {
+    expect(hasBudgetCaps({ maxCostPerRun: 1 })).toBe(true);
+    expect(hasBudgetCaps({ maxTokensPerRun: 100 })).toBe(true);
+    expect(hasBudgetCaps({ maxCostPerProject: 5 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateBudget
+// ---------------------------------------------------------------------------
+
+describe('evaluateBudget', () => {
+  const usage = { runCostUsd: 0, runTokens: 0, projectCostUsd: 0 };
+
+  it('does not fire when within all caps', () => {
+    const caps: BudgetCaps = { maxCostPerRun: 1, maxTokensPerRun: 1000, maxCostPerProject: 10 };
+    const v = evaluateBudget(caps, { runCostUsd: 0.5, runTokens: 500, projectCostUsd: 5 });
+    expect(v.exceeded).toBe(false);
+  });
+
+  it('fires on run cost at or above the cap', () => {
+    const v = evaluateBudget({ maxCostPerRun: 1 }, { ...usage, runCostUsd: 1.0 });
+    expect(v.exceeded).toBe(true);
+    expect(v.scope).toBe('run');
+    expect(v.kind).toBe('cost');
+    expect(v.cap).toBe(1);
+    expect(v.spent).toBe(1);
+  });
+
+  it('fires on run tokens at or above the cap', () => {
+    const v = evaluateBudget({ maxTokensPerRun: 1000 }, { ...usage, runTokens: 1200 });
+    expect(v.exceeded).toBe(true);
+    expect(v.scope).toBe('run');
+    expect(v.kind).toBe('tokens');
+    expect(v.spent).toBe(1200);
+  });
+
+  it('fires on project cost at or above the cap', () => {
+    const v = evaluateBudget({ maxCostPerProject: 10 }, { ...usage, projectCostUsd: 10.5 });
+    expect(v.exceeded).toBe(true);
+    expect(v.scope).toBe('project');
+    expect(v.kind).toBe('cost');
+    expect(v.spent).toBe(10.5);
+  });
+
+  it('prefers run cost, then run tokens, then project cost', () => {
+    const caps: BudgetCaps = { maxCostPerRun: 1, maxTokensPerRun: 100, maxCostPerProject: 5 };
+    const v = evaluateBudget(caps, { runCostUsd: 2, runTokens: 200, projectCostUsd: 6 });
+    expect(v.scope).toBe('run');
+    expect(v.kind).toBe('cost');
+  });
+
+  it('ignores caps left undefined', () => {
+    const v = evaluateBudget({ maxCostPerProject: 5 }, { runCostUsd: 999, runTokens: 999999, projectCostUsd: 1 });
+    expect(v.exceeded).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-project spend ledger
+// ---------------------------------------------------------------------------
+
+describe('project spend ledger', () => {
+  it('starts at zero for an unseen project', () => {
+    expect(loadProjectSpend(PROJECT).spentUsd).toBe(0);
+  });
+
+  it('accumulates spend across records and persists atomically', () => {
+    expect(recordProjectSpend(PROJECT, 0.5)).toBeCloseTo(0.5);
+    expect(recordProjectSpend(PROJECT, 0.25)).toBeCloseTo(0.75);
+    expect(loadProjectSpend(PROJECT).spentUsd).toBeCloseTo(0.75);
+    // File is real JSON on disk.
+    const parsed = JSON.parse(fs.readFileSync(projectBudgetPath(PROJECT), 'utf-8'));
+    expect(parsed.spentUsd).toBeCloseTo(0.75);
+  });
+
+  it('ignores non-positive deltas', () => {
+    recordProjectSpend(PROJECT, 1);
+    expect(recordProjectSpend(PROJECT, 0)).toBeCloseTo(1);
+    expect(recordProjectSpend(PROJECT, -5)).toBeCloseTo(1);
+  });
+
+  it('reset clears the ledger', () => {
+    recordProjectSpend(PROJECT, 2);
+    resetProjectSpend(PROJECT);
+    expect(loadProjectSpend(PROJECT).spentUsd).toBe(0);
+  });
+
+  it('recovers gracefully from a corrupt ledger file', () => {
+    fs.mkdirSync(path.dirname(projectBudgetPath(PROJECT)), { recursive: true });
+    fs.writeFileSync(projectBudgetPath(PROJECT), 'not json');
+    expect(loadProjectSpend(PROJECT).spentUsd).toBe(0);
+  });
+
+  it('keys different project dirs separately', () => {
+    const other = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-proj-'));
+    recordProjectSpend(PROJECT, 1);
+    recordProjectSpend(other, 3);
+    expect(loadProjectSpend(PROJECT).spentUsd).toBeCloseTo(1);
+    expect(loadProjectSpend(other).spentUsd).toBeCloseTo(3);
+    fs.rmSync(other, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatBudgetHalt
+// ---------------------------------------------------------------------------
+
+describe('formatBudgetHalt', () => {
+  it('formats a cost halt with dollar units', () => {
+    const s = formatBudgetHalt({ exceeded: true, scope: 'run', kind: 'cost', spent: 1.5, cap: 1 });
+    expect(s).toContain('run cost');
+    expect(s).toContain('$1.5000');
+    expect(s).toContain('$1.00');
+  });
+
+  it('formats a token halt without dollar units', () => {
+    const s = formatBudgetHalt({ exceeded: true, scope: 'run', kind: 'tokens', spent: 1200, cap: 1000 });
+    expect(s).toContain('tokens');
+    expect(s).toContain('1200');
+    expect(s).not.toContain('$');
+  });
+
+  it('returns empty string when not exceeded', () => {
+    expect(formatBudgetHalt({ exceeded: false })).toBe('');
+  });
+});

--- a/tests/headless-governance.test.ts
+++ b/tests/headless-governance.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Integration tests for governance wiring in the headless runner (#189):
+ * budget halt (run cost, run tokens, project cost) with exit code 3, the policy
+ * deny path, and the audit run log it emits (run_start … run_end + budget_event,
+ * verifiable hash chain).
+ *
+ * Heavy deps are mocked (no network, no real tools). os.homedir is redirected to
+ * a temp dir so the run log + project ledger + conf store land under tmp.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { EventEmitter } from 'events';
+
+const { tmpHome } = vi.hoisted(() => {
+  const _fs = require('fs') as typeof import('fs');
+  const _path = require('path') as typeof import('path');
+  const _os = require('os') as typeof import('os');
+  const dir = _fs.mkdtempSync(_path.join(_os.tmpdir(), 'calliope-hlgov-test-'));
+  return { tmpHome: dir };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpHome };
+});
+
+// -- Config mock (test-controlled budget/policy) ----------------------------
+let budgetCaps: Record<string, number> | undefined;
+let policyConfig: { command?: string } | undefined;
+
+vi.mock('../src/config.js', () => ({
+  default: {},
+  get: vi.fn((key: string) => {
+    if (key === 'maxIterations') return 10;
+    if (key === 'budget') return budgetCaps;
+    if (key === 'policy') return policyConfig;
+    if (key === 'audit') return undefined; // enabled by default
+    if (key === 'defaultProvider') return 'anthropic';
+    if (key === 'defaultModel') return 'claude-sonnet-4-6';
+    return undefined;
+  }),
+  getConfig: vi.fn(() => ({ defaultProvider: 'anthropic' })),
+  getApiKey: vi.fn(),
+  getBaseUrl: vi.fn(),
+  getConfiguredProviders: vi.fn(() => []),
+}));
+
+const mockChat = vi.fn();
+const mockExecuteTool = vi.fn();
+
+vi.mock('../src/providers/index.js', () => ({
+  chat: (...args: unknown[]) => mockChat(...args),
+  selectProvider: (p: string) => p || 'anthropic',
+}));
+
+vi.mock('../src/tools.js', () => ({
+  TOOLS: [],
+  executeTool: (...args: unknown[]) => mockExecuteTool(...args),
+  getTools: vi.fn(() => []),
+}));
+
+vi.mock('../src/memory.js', () => ({
+  buildMemoryContext: vi.fn(() => ''),
+}));
+
+vi.mock('../src/local-model.js', () => ({
+  getSystemPromptForProvider: vi.fn(() => 'system'),
+  isLocalBackend: vi.fn(() => false),
+}));
+
+// child_process for the policy hook
+const spawnMock = vi.fn();
+vi.mock('child_process', () => ({ spawn: (...a: unknown[]) => spawnMock(...a) }));
+
+import { runHeadless } from '../src/headless.js';
+import { readRunLog, verifyChain, resetRunLogs, type RunLogLine } from '../src/runlog.js';
+import { recordProjectSpend, resetProjectSpend } from '../src/budget.js';
+
+const RUNS_DIR = path.join(tmpHome, '.calliope-cli', 'runs');
+const CWD = tmpHome;
+
+function finalResponse(content = 'done', usage = { inputTokens: 10, outputTokens: 5 }) {
+  return { content, toolCalls: [], finishReason: 'stop', usage };
+}
+function toolResponse(usage = { inputTokens: 10, outputTokens: 5 }) {
+  return {
+    content: '',
+    toolCalls: [{ id: 'tc1', name: 'shell', arguments: { command: 'ls' } }],
+    finishReason: 'tool_use',
+    usage,
+  };
+}
+
+/** The single run-log file written by a headless run in the fresh tmp runs dir. */
+function onlyRunLog(): RunLogLine[] {
+  const files = fs.readdirSync(RUNS_DIR).filter((f) => f.endsWith('.jsonl'));
+  expect(files).toHaveLength(1);
+  return readRunLog(path.join(RUNS_DIR, files[0]));
+}
+
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  budgetCaps = undefined;
+  policyConfig = undefined;
+  mockChat.mockReset();
+  mockExecuteTool.mockReset();
+  spawnMock.mockReset();
+  resetRunLogs();
+  resetProjectSpend(CWD);
+  fs.rmSync(RUNS_DIR, { recursive: true, force: true });
+  // Silence (and capture) the JSON/stderr the runner writes.
+  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function stderrText(): string {
+  return stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+}
+
+// ---------------------------------------------------------------------------
+// Budget halt
+// ---------------------------------------------------------------------------
+
+describe('headless budget halt', () => {
+  it('exits 3 when the run cost cap is exceeded', async () => {
+    budgetCaps = { maxCostPerRun: 0.00001 };
+    // claude-sonnet-4-6 = $3/M input; 10k input ≈ $0.00003 > cap.
+    mockChat.mockResolvedValueOnce(finalResponse('big', { inputTokens: 10000, outputTokens: 0 }));
+
+    const code = await runHeadless({ prompt: 'go', provider: 'anthropic', model: 'claude-sonnet-4-6', outputMode: 'json', cwd: CWD });
+
+    expect(code).toBe(3);
+    expect(stderrText()).toContain('Budget cap reached');
+  });
+
+  it('exits 3 when the run token cap is exceeded', async () => {
+    budgetCaps = { maxTokensPerRun: 100 };
+    mockChat.mockResolvedValueOnce(finalResponse('big', { inputTokens: 200, outputTokens: 0 }));
+
+    const code = await runHeadless({ prompt: 'go', provider: 'anthropic', model: 'claude-sonnet-4-6', outputMode: 'json', cwd: CWD });
+    expect(code).toBe(3);
+  });
+
+  it('exits 3 up-front when the project cost cap is already spent (no chat call)', async () => {
+    budgetCaps = { maxCostPerProject: 0.001 };
+    recordProjectSpend(CWD, 0.01); // already over cap
+
+    const code = await runHeadless({ prompt: 'go', provider: 'anthropic', model: 'claude-sonnet-4-6', outputMode: 'json', cwd: CWD });
+
+    expect(code).toBe(3);
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+
+  it('records a budget_event and a run_end(budget) in a verifiable run log', async () => {
+    budgetCaps = { maxCostPerRun: 0.00001 };
+    mockChat.mockResolvedValueOnce(finalResponse('big', { inputTokens: 10000, outputTokens: 0 }));
+
+    await runHeadless({ prompt: 'go', provider: 'anthropic', model: 'claude-sonnet-4-6', outputMode: 'json', cwd: CWD });
+
+    const lines = onlyRunLog();
+    expect(verifyChain(lines).ok).toBe(true);
+    expect(lines.some((l) => l.type === 'run_start')).toBe(true);
+    expect(lines.some((l) => l.type === 'budget_event')).toBe(true);
+    const end = lines.find((l) => l.type === 'run_end') as unknown as { exitReason: string };
+    expect(end.exitReason).toBe('budget');
+  });
+
+  it('completes normally (exit 0) when under budget', async () => {
+    budgetCaps = { maxCostPerRun: 100 };
+    mockChat.mockResolvedValueOnce(finalResponse('all good'));
+
+    const code = await runHeadless({ prompt: 'go', provider: 'anthropic', model: 'claude-sonnet-4-6', outputMode: 'json', cwd: CWD });
+    expect(code).toBe(0);
+    const lines = onlyRunLog();
+    const end = lines.find((l) => l.type === 'run_end') as unknown as { exitReason: string };
+    expect(end.exitReason).toBe('completed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Policy hook
+// ---------------------------------------------------------------------------
+
+describe('headless policy hook', () => {
+  function fakeDenyProc(reason: string) {
+    const proc = new EventEmitter() as EventEmitter & {
+      pid: number; stdin: { write: () => void; end: () => void }; stdout: EventEmitter; stderr: EventEmitter; kill: () => void;
+    };
+    proc.pid = 2147483646;
+    proc.stdin = { write: () => {}, end: () => {} };
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = () => {};
+    // Deny asynchronously after listeners attach.
+    queueMicrotask(() => {
+      proc.stderr.emit('data', Buffer.from(reason));
+      proc.emit('close', 1);
+    });
+    return proc;
+  }
+
+  it('denies a tool call and never executes it, then completes', async () => {
+    policyConfig = { command: 'policy.sh' };
+    spawnMock.mockImplementation(() => fakeDenyProc('blocked by policy'));
+
+    // First response asks for a tool; second is the final answer.
+    mockChat
+      .mockResolvedValueOnce(toolResponse())
+      .mockResolvedValueOnce(finalResponse('finished without the tool'));
+
+    const code = await runHeadless({ prompt: 'go', provider: 'anthropic', model: 'claude-sonnet-4-6', outputMode: 'json', cwd: CWD });
+
+    expect(code).toBe(0);
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+
+    const lines = onlyRunLog();
+    const policyEvent = lines.find((l) => l.type === 'policy_event') as unknown as { decision: string; reason: string };
+    expect(policyEvent.decision).toBe('deny');
+    expect(policyEvent.reason).toContain('blocked by policy');
+    expect(verifyChain(lines).ok).toBe(true);
+  });
+
+  it('executes the tool when policy allows', async () => {
+    policyConfig = { command: 'policy.sh' };
+    spawnMock.mockImplementation(() => {
+      const proc = new EventEmitter() as EventEmitter & {
+        pid: number; stdin: { write: () => void; end: () => void }; stdout: EventEmitter; stderr: EventEmitter; kill: () => void;
+      };
+      proc.pid = 2147483646;
+      proc.stdin = { write: () => {}, end: () => {} };
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = () => {};
+      queueMicrotask(() => proc.emit('close', 0));
+      return proc;
+    });
+    mockExecuteTool.mockResolvedValue({ result: 'ok', isError: false });
+    mockChat
+      .mockResolvedValueOnce(toolResponse())
+      .mockResolvedValueOnce(finalResponse('done'));
+
+    const code = await runHeadless({ prompt: 'go', provider: 'anthropic', model: 'claude-sonnet-4-6', outputMode: 'json', cwd: CWD });
+    expect(code).toBe(0);
+    expect(mockExecuteTool).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/headless-retry.test.ts
+++ b/tests/headless-retry.test.ts
@@ -15,8 +15,10 @@ vi.mock('../src/config.js', () => ({
   default: {},
   get: vi.fn((key: string) => {
     if (key === 'maxIterations') return 10;
+    if (key === 'audit') return { enabled: false }; // no run-log disk writes in tests
     return undefined;
   }),
+  getConfig: vi.fn(() => ({})),
   getApiKey: vi.fn(),
   getBaseUrl: vi.fn(),
   getConfiguredProviders: vi.fn(() => []),
@@ -39,6 +41,7 @@ vi.mock('../src/tools.js', () => ({
 vi.mock('../src/types.js', () => ({
   getSystemPrompt: vi.fn(() => 'You are a helpful assistant.'),
   DEFAULT_MODELS: { anthropic: 'claude-3-5-sonnet-20241022' },
+  calculateCost: vi.fn(() => 0),
 }));
 
 vi.mock('../src/memory.js', () => ({

--- a/tests/loop-exec.test.ts
+++ b/tests/loop-exec.test.ts
@@ -82,8 +82,10 @@ vi.mock('../src/config.js', () => ({
   default: {},
   get: vi.fn((key: string) => {
     if (key === 'maxIterations') return 10;
+    if (key === 'audit') return { enabled: false }; // no run-log disk writes in tests
     return undefined;
   }),
+  getConfig: vi.fn(() => ({})),
   getApiKey: vi.fn(),
   getBaseUrl: vi.fn(),
   getConfiguredProviders: vi.fn(() => []),

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for src/policy.ts — the pre-tool policy hook.
+ *
+ * child_process is mocked so no real process is spawned. Covers: no-policy
+ * pass-through, allow (exit 0), deny (non-zero + stderr reason), fail-closed on
+ * timeout, fail-closed on spawn error, stdin delivery of the tool-call JSON, and
+ * config-driven enablement.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// -- Mocks (declared before importing the module under test) ----------------
+
+let policyConfig: { command?: string; timeoutMs?: number } | undefined;
+vi.mock('../src/config.js', () => ({
+  default: {},
+  get: (key: string) => (key === 'policy' ? policyConfig : undefined),
+}));
+
+const spawnMock = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+import { evaluatePolicy, isPolicyEnabled, getPolicyCommand } from '../src/policy.js';
+import type { ToolCall } from '../src/types.js';
+
+// -- Fake child process -----------------------------------------------------
+
+interface FakeProc extends EventEmitter {
+  pid: number;
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeProc(): FakeProc {
+  const proc = new EventEmitter() as FakeProc;
+  proc.pid = 2147483646; // negative-group kill will ESRCH; harmless
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn(() => proc.emit('close', null));
+  return proc;
+}
+
+const toolCall: ToolCall = { id: 't1', name: 'shell', arguments: { command: 'rm -rf /' } };
+
+beforeEach(() => {
+  policyConfig = undefined;
+  spawnMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe('getPolicyCommand / isPolicyEnabled', () => {
+  it('is disabled when no command configured', () => {
+    policyConfig = undefined;
+    expect(getPolicyCommand()).toBeUndefined();
+    expect(isPolicyEnabled()).toBe(false);
+  });
+
+  it('ignores a blank command', () => {
+    policyConfig = { command: '   ' };
+    expect(getPolicyCommand()).toBeUndefined();
+    expect(isPolicyEnabled()).toBe(false);
+  });
+
+  it('is enabled when a command is configured', () => {
+    policyConfig = { command: '/usr/local/bin/policy' };
+    expect(getPolicyCommand()).toBe('/usr/local/bin/policy');
+    expect(isPolicyEnabled()).toBe(true);
+  });
+
+  it('honours an explicit command override', () => {
+    expect(isPolicyEnabled({ command: 'x' })).toBe(true);
+  });
+});
+
+describe('evaluatePolicy', () => {
+  it('allows immediately when no policy is configured', async () => {
+    const result = await evaluatePolicy(toolCall);
+    expect(result.decision).toBe('allow');
+    expect(result.source).toBe('none');
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('allows on exit code 0 and feeds the tool-call JSON on stdin', async () => {
+    const proc = makeFakeProc();
+    spawnMock.mockReturnValue(proc);
+
+    const p = evaluatePolicy(toolCall, { command: 'allow.sh' });
+    proc.emit('close', 0);
+    const result = await p;
+
+    expect(result.decision).toBe('allow');
+    expect(result.source).toBe('policy');
+    const written = proc.stdin.write.mock.calls[0][0] as string;
+    expect(JSON.parse(written)).toEqual({ id: 't1', name: 'shell', arguments: { command: 'rm -rf /' } });
+    expect(proc.stdin.end).toHaveBeenCalled();
+  });
+
+  it('denies on non-zero exit with stderr as the reason', async () => {
+    const proc = makeFakeProc();
+    spawnMock.mockReturnValue(proc);
+
+    const p = evaluatePolicy(toolCall, { command: 'deny.sh' });
+    proc.stderr.emit('data', Buffer.from('destructive command blocked'));
+    proc.emit('close', 3);
+    const result = await p;
+
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toBe('destructive command blocked');
+  });
+
+  it('denies with a synthesized reason when stderr is empty', async () => {
+    const proc = makeFakeProc();
+    spawnMock.mockReturnValue(proc);
+
+    const p = evaluatePolicy(toolCall, { command: 'deny.sh' });
+    proc.emit('close', 1);
+    const result = await p;
+
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain('exit 1');
+  });
+
+  it('fails closed (deny) on timeout', async () => {
+    const proc = makeFakeProc();
+    spawnMock.mockReturnValue(proc);
+    // Make the group-signal throw so the code falls back to proc.kill(), which
+    // emits 'close' — simulating the process dying from the timeout signal.
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('no such process group');
+    });
+
+    const p = evaluatePolicy(toolCall, { command: 'hang.sh', timeoutMs: 20 });
+    const result = await p;
+
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain('timed out');
+    expect(proc.kill).toHaveBeenCalled();
+  });
+
+  it('fails closed (deny) when the process errors', async () => {
+    const proc = makeFakeProc();
+    spawnMock.mockReturnValue(proc);
+
+    const p = evaluatePolicy(toolCall, { command: 'missing.sh' });
+    proc.emit('error', new Error('spawn ENOENT'));
+    const result = await p;
+
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain('ENOENT');
+  });
+
+  it('fails closed (deny) when spawn throws synchronously', async () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error('cannot spawn');
+    });
+    const result = await evaluatePolicy(toolCall, { command: 'x' });
+    expect(result.decision).toBe('deny');
+    expect(result.reason).toContain('cannot spawn');
+  });
+
+  it('uses the configured command when no override is given', async () => {
+    policyConfig = { command: 'configured.sh' };
+    const proc = makeFakeProc();
+    spawnMock.mockReturnValue(proc);
+
+    const p = evaluatePolicy(toolCall);
+    proc.emit('close', 0);
+    await p;
+
+    expect(spawnMock).toHaveBeenCalledWith('sh', ['-c', 'configured.sh'], expect.anything());
+  });
+});

--- a/tests/replay.test.ts
+++ b/tests/replay.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for src/replay.ts — read-only run-log rendering.
+ *
+ * Covers: target resolution (path + session id), human + JSON rendering, cost
+ * accumulation, tool call/result pairing, broken-chain detection, and the exit
+ * codes (0 ok, 4 broken, 1 not found).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const { tmpHome } = vi.hoisted(() => {
+  const _fs = require('fs') as typeof import('fs');
+  const _path = require('path') as typeof import('path');
+  const _os = require('os') as typeof import('os');
+  const dir = _fs.mkdtempSync(_path.join(_os.tmpdir(), 'calliope-replay-test-'));
+  return { tmpHome: dir };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpHome };
+});
+
+import { RunLog, readRunLog, verifyChain, runLogPath, resetRunLogs } from '../src/runlog.js';
+import { runReplay, renderReplay, renderReplayJson, resolveReplayTarget } from '../src/replay.js';
+
+const RUNS_DIR = path.join(tmpHome, '.calliope-cli', 'runs');
+
+let counter = 0;
+function freshSession(): string {
+  return `session_replay_${Date.now()}_${counter++}`;
+}
+
+/** Write a small, complete trace and return its session id + file path. */
+async function writeTrace(): Promise<{ session: string; file: string }> {
+  const session = freshSession();
+  const log = RunLog.open(session);
+  log.runStart({ session, cwd: '/tmp/proj', provider: 'anthropic', model: 'claude', config: {} });
+  log.userPrompt('list the files');
+  log.assistantMessage({ content: 'calling shell', tokens: { input: 20, output: 8 }, cost: 0.002 });
+  log.toolCall({ id: 'tc1', name: 'shell', args: { command: 'ls -la' } });
+  log.toolResult({ id: 'tc1', result: 'total 0\nfile.txt', isError: false, durationMs: 9 });
+  log.assistantMessage({ content: 'done', tokens: { input: 30, output: 4 }, cost: 0.003 });
+  log.runEnd({ totals: { inputTokens: 50, outputTokens: 12, cost: 0.005, toolCalls: 1, durationMs: 42 }, exitReason: 'completed' });
+  await log.flush();
+  return { session, file: runLogPath(session, RUNS_DIR) };
+}
+
+function capture(): { out: string[]; err: string[]; stdout: (s: string) => void; stderr: (s: string) => void } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, stdout: (s) => out.push(s), stderr: (s) => err.push(s) };
+}
+
+beforeEach(() => resetRunLogs());
+afterAll(() => fs.rmSync(tmpHome, { recursive: true, force: true }));
+
+// ---------------------------------------------------------------------------
+
+describe('resolveReplayTarget', () => {
+  it('resolves a direct file path', async () => {
+    const { file } = await writeTrace();
+    expect(resolveReplayTarget(file)).toBe(file);
+  });
+
+  it('resolves a bare session id under the audit dir', async () => {
+    const { session, file } = await writeTrace();
+    expect(resolveReplayTarget(session)).toBe(file);
+  });
+
+  it('returns null for an unknown target', () => {
+    expect(resolveReplayTarget('does-not-exist')).toBeNull();
+  });
+});
+
+describe('renderReplay', () => {
+  it('renders events chronologically with pairing and cost accumulation', async () => {
+    const { file } = await writeTrace();
+    const lines = readRunLog(file);
+    const text = renderReplay(lines, verifyChain(lines));
+
+    expect(text).toContain('run start');
+    expect(text).toContain('user: list the files');
+    expect(text).toContain('shell');
+    expect(text).toContain('#tc1'); // tool call/result pairing id
+    expect(text).toContain('run end');
+    // cost accumulation = 0.002 + 0.003
+    expect(text).toContain('Cumulative assistant cost: $0.0050');
+    expect(text).toContain('Hash chain: OK');
+  });
+
+  it('reports a broken chain with the line number', async () => {
+    const { file } = await writeTrace();
+    const lines = readRunLog(file);
+    (lines[1] as unknown as { text: string }).text = 'tampered';
+    const text = renderReplay(lines, verifyChain(lines));
+    expect(text).toContain('Hash chain: BROKEN at line 2');
+  });
+
+  it('renders budget, policy, error-result, and unknown event types', () => {
+    // Synthetic lines — renderReplay is pure and does not verify hashes.
+    const lines = [
+      { v: 1, seq: 0, ts: '2026-07-05T10:00:00.000Z', type: 'policy_event', tool: 'shell', decision: 'deny', reason: 'blocked', prev_hash: '', hash: 'a' },
+      { v: 1, seq: 1, ts: '2026-07-05T10:00:01.000Z', type: 'tool_result', id: 'x', result: 'boom', isError: true, durationMs: 3, prev_hash: 'a', hash: 'b' },
+      { v: 1, seq: 2, ts: '2026-07-05T10:00:02.000Z', type: 'budget_event', scope: 'run', kind: 'cost', spent: 2, cap: 1, message: 'Run cost cap reached', prev_hash: 'b', hash: 'c' },
+      { v: 1, seq: 3, ts: '2026-07-05T10:00:03.000Z', type: 'mystery', prev_hash: 'c', hash: 'd' },
+    ] as unknown as Parameters<typeof renderReplay>[0];
+
+    const text = renderReplay(lines, { ok: true });
+    expect(text).toContain('policy: DENY shell');
+    expect(text).toContain('blocked');
+    expect(text).toContain('✗'); // errored tool result
+    expect(text).toContain('budget: Run cost cap reached');
+    expect(text).toContain('mystery'); // default branch
+  });
+});
+
+describe('renderReplayJson', () => {
+  it('emits parseable JSON with events, verification, and summary', async () => {
+    const { file } = await writeTrace();
+    const lines = readRunLog(file);
+    const parsed = JSON.parse(renderReplayJson(lines, verifyChain(lines)));
+    expect(parsed.events).toHaveLength(lines.length);
+    expect(parsed.verification.ok).toBe(true);
+    expect(parsed.summary.toolCalls).toBe(1);
+    expect(parsed.summary.cumulativeCost).toBeCloseTo(0.005);
+  });
+});
+
+describe('runReplay exit codes', () => {
+  it('returns 0 and prints a trace for a valid file', async () => {
+    const { file } = await writeTrace();
+    const cap = capture();
+    const code = runReplay(file, { stdout: cap.stdout, stderr: cap.stderr });
+    expect(code).toBe(0);
+    expect(cap.out.join('')).toContain('Hash chain: OK');
+  });
+
+  it('resolves and replays by session id', async () => {
+    const { session } = await writeTrace();
+    const cap = capture();
+    const code = runReplay(session, { stdout: cap.stdout, stderr: cap.stderr });
+    expect(code).toBe(0);
+  });
+
+  it('returns 4 when the hash chain is broken', async () => {
+    const { file } = await writeTrace();
+    const lines = readRunLog(file);
+    (lines[2] as unknown as { cost: number }).cost = 999; // tamper
+    fs.writeFileSync(file, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+
+    const cap = capture();
+    const code = runReplay(file, { stdout: cap.stdout, stderr: cap.stderr });
+    expect(code).toBe(4);
+    expect(cap.out.join('')).toContain('BROKEN');
+  });
+
+  it('returns 1 for a missing target', () => {
+    const cap = capture();
+    const code = runReplay('nope', { stdout: cap.stdout, stderr: cap.stderr });
+    expect(code).toBe(1);
+    expect(cap.err.join('')).toContain('not found');
+  });
+
+  it('returns 1 when no target is given', () => {
+    const cap = capture();
+    const code = runReplay(undefined, { stdout: cap.stdout, stderr: cap.stderr });
+    expect(code).toBe(1);
+    expect(cap.err.join('')).toContain('Usage');
+  });
+
+  it('returns 1 for an unreadable (corrupt) trace', () => {
+    const file = path.join(RUNS_DIR, 'corrupt.jsonl');
+    fs.mkdirSync(RUNS_DIR, { recursive: true });
+    fs.writeFileSync(file, 'not json at all\n');
+    const cap = capture();
+    const code = runReplay(file, { stdout: cap.stdout, stderr: cap.stderr });
+    expect(code).toBe(1);
+  });
+
+  it('emits JSON output with --json', async () => {
+    const { file } = await writeTrace();
+    const cap = capture();
+    const code = runReplay(file, { json: true, stdout: cap.stdout, stderr: cap.stderr });
+    expect(code).toBe(0);
+    const parsed = JSON.parse(cap.out.join(''));
+    expect(parsed.verification.ok).toBe(true);
+  });
+});

--- a/tests/runlog.test.ts
+++ b/tests/runlog.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for src/runlog.ts — the append-only audit run log.
+ *
+ * Covers: redaction, canonicalization, event emission, the tamper-evidence hash
+ * chain (write + verify + break detection), chain resumption across opens,
+ * reading, rotation, and the on/off switch.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// A temp home so the conf store and default runs dir live under tmp, not the
+// real user home. Created before modules load (vi.hoisted).
+const { tmpHome } = vi.hoisted(() => {
+  const _fs = require('fs') as typeof import('fs');
+  const _path = require('path') as typeof import('path');
+  const _os = require('os') as typeof import('os');
+  const dir = _fs.mkdtempSync(_path.join(_os.tmpdir(), 'calliope-runlog-test-'));
+  return { tmpHome: dir };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpHome };
+});
+
+import {
+  RunLog,
+  redactSecrets,
+  canonicalize,
+  verifyChain,
+  readRunLog,
+  rotateRuns,
+  runLogPath,
+  resolveAuditSettings,
+  resetRunLogs,
+  RUNLOG_SCHEMA_VERSION,
+  type RunLogLine,
+} from '../src/runlog.js';
+
+const RUNS_DIR = path.join(tmpHome, '.calliope-cli', 'runs');
+
+let counter = 0;
+function freshSession(): string {
+  return `session_test_${Date.now()}_${counter++}`;
+}
+
+beforeEach(() => {
+  resetRunLogs();
+});
+
+afterAll(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+describe('redactSecrets', () => {
+  it('strips values under secret-named keys', () => {
+    const out = redactSecrets({ apiKey: 'sk-ant-abc', token: 'xyz', keep: 'ok' }) as Record<string, unknown>;
+    expect(out.apiKey).toBe('[REDACTED]');
+    expect(out.token).toBe('[REDACTED]');
+    expect(out.keep).toBe('ok');
+  });
+
+  it('masks secret-looking string values in place', () => {
+    const out = redactSecrets({ note: 'use sk-ant-ABCDEFGHIJKLMNOP123 here' }) as Record<string, unknown>;
+    expect(out.note).toContain('[REDACTED]');
+    expect(out.note).not.toContain('ABCDEFGHIJKLMNOP');
+  });
+
+  it('recurses through nested objects and arrays', () => {
+    const out = redactSecrets({
+      providers: { anthropic: { apiKey: 'sk-secret', baseUrl: 'https://x' } },
+      list: [{ password: 'p' }, 'plain'],
+    }) as Record<string, unknown>;
+    const providers = out.providers as Record<string, Record<string, unknown>>;
+    expect(providers.anthropic.apiKey).toBe('[REDACTED]');
+    expect(providers.anthropic.baseUrl).toBe('https://x');
+    const list = out.list as Array<Record<string, unknown> | string>;
+    expect((list[0] as Record<string, unknown>).password).toBe('[REDACTED]');
+    expect(list[1]).toBe('plain');
+  });
+
+  it('leaves non-secret primitives untouched', () => {
+    expect(redactSecrets(42)).toBe(42);
+    expect(redactSecrets(null)).toBe(null);
+    expect(redactSecrets('hello world')).toBe('hello world');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonicalization
+// ---------------------------------------------------------------------------
+
+describe('canonicalize', () => {
+  it('is independent of key insertion order', () => {
+    expect(canonicalize({ b: 1, a: 2 })).toBe(canonicalize({ a: 2, b: 1 }));
+  });
+
+  it('preserves array order', () => {
+    expect(canonicalize([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('handles nested structures deterministically', () => {
+    const a = canonicalize({ x: { c: 1, a: [1, { z: 0, y: 9 }] } });
+    const b = canonicalize({ x: { a: [1, { y: 9, z: 0 }], c: 1 } });
+    expect(a).toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Writing + hash chain
+// ---------------------------------------------------------------------------
+
+describe('RunLog writing', () => {
+  it('writes a valid, versioned, chained trace', async () => {
+    const session = freshSession();
+    const log = RunLog.open(session);
+    log.runStart({ session, cwd: '/tmp/proj', provider: 'anthropic', model: 'claude', config: {} });
+    log.userPrompt('do the thing');
+    log.assistantMessage({ content: 'ok', tokens: { input: 10, output: 5 }, cost: 0.001 });
+    log.toolCall({ id: 't1', name: 'shell', args: { command: 'ls' } });
+    log.toolResult({ id: 't1', result: 'a\nb', isError: false, durationMs: 12 });
+    log.runEnd({ totals: { inputTokens: 10, outputTokens: 5, cost: 0.001, toolCalls: 1, durationMs: 30 }, exitReason: 'completed' });
+    await log.flush();
+
+    const lines = readRunLog(runLogPath(session, RUNS_DIR));
+    expect(lines).toHaveLength(6);
+    expect(lines[0].type).toBe('run_start');
+    expect(lines[0].v).toBe(RUNLOG_SCHEMA_VERSION);
+    expect(lines.map((l) => l.seq)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(lines[0].prev_hash).toBe('');
+    expect(lines[1].prev_hash).toBe(lines[0].hash);
+    expect(verifyChain(lines).ok).toBe(true);
+  });
+
+  it('redacts credentials in the run_start config snapshot', async () => {
+    const session = freshSession();
+    const log = RunLog.open(session);
+    log.runStart({
+      session,
+      cwd: '/tmp',
+      provider: 'anthropic',
+      model: 'claude',
+      config: { providers: { anthropic: { apiKey: 'sk-ant-SUPERSECRET-KEY-1234567' } } },
+    });
+    await log.flush();
+
+    const raw = fs.readFileSync(runLogPath(session, RUNS_DIR), 'utf-8');
+    expect(raw).not.toContain('SUPERSECRET');
+    expect(raw).toContain('[REDACTED]');
+  });
+
+  it('redacts secrets in tool_call args', async () => {
+    const session = freshSession();
+    const log = RunLog.open(session);
+    log.toolCall({ id: 't1', name: 'http', args: { token: 'abc123', url: 'https://x' } });
+    await log.flush();
+    const lines = readRunLog(runLogPath(session, RUNS_DIR));
+    expect((lines[0] as unknown as { args: Record<string, unknown> }).args.token).toBe('[REDACTED]');
+    expect((lines[0] as unknown as { args: Record<string, unknown> }).args.url).toBe('https://x');
+  });
+
+  it('truncates long tool results', async () => {
+    const session = freshSession();
+    const log = RunLog.open(session);
+    log.toolResult({ id: 't1', result: 'x'.repeat(5000), isError: false, durationMs: 1 }, 100);
+    await log.flush();
+    const lines = readRunLog(runLogPath(session, RUNS_DIR));
+    const result = (lines[0] as unknown as { result: string }).result;
+    expect(result.length).toBeLessThan(200);
+    expect(result).toContain('truncated');
+  });
+
+  it('does not write anything when disabled', async () => {
+    const session = freshSession();
+    const log = RunLog.open(session, { enabled: false });
+    expect(log.enabled).toBe(false);
+    log.runStart({ session, cwd: '/tmp', provider: 'p', model: 'm', config: {} });
+    log.userPrompt('hi');
+    await log.flush();
+    expect(fs.existsSync(runLogPath(session, RUNS_DIR))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verification / tamper detection
+// ---------------------------------------------------------------------------
+
+describe('verifyChain', () => {
+  async function writeTrace(): Promise<{ file: string }> {
+    const session = freshSession();
+    const log = RunLog.open(session);
+    log.runStart({ session, cwd: '/tmp', provider: 'p', model: 'm', config: {} });
+    log.userPrompt('one');
+    log.assistantMessage({ content: 'two', tokens: { input: 1, output: 1 }, cost: 0 });
+    await log.flush();
+    return { file: runLogPath(session, RUNS_DIR) };
+  }
+
+  it('accepts an untouched trace', async () => {
+    const { file } = await writeTrace();
+    expect(verifyChain(readRunLog(file)).ok).toBe(true);
+  });
+
+  it('detects a mutated payload', async () => {
+    const { file } = await writeTrace();
+    const lines = readRunLog(file);
+    (lines[1] as unknown as { text: string }).text = 'tampered';
+    const result = verifyChain(lines);
+    expect(result.ok).toBe(false);
+    expect(result.brokenAtLine).toBe(2);
+    expect(result.reason).toBe('hash mismatch');
+  });
+
+  it('detects a deleted line via prev_hash mismatch', async () => {
+    const { file } = await writeTrace();
+    const lines = readRunLog(file);
+    lines.splice(1, 1); // drop the user_prompt
+    const result = verifyChain(lines);
+    expect(result.ok).toBe(false);
+    expect(result.brokenAtLine).toBe(2);
+    expect(result.reason).toBe('prev_hash mismatch');
+  });
+
+  it('reports ok for an empty trace', () => {
+    expect(verifyChain([]).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chain resumption across opens
+// ---------------------------------------------------------------------------
+
+describe('RunLog chain resumption', () => {
+  it('continues the hash chain when re-opened from disk', async () => {
+    const session = freshSession();
+    const first = RunLog.open(session);
+    first.runStart({ session, cwd: '/tmp', provider: 'p', model: 'm', config: {} });
+    first.userPrompt('turn one');
+    await first.flush();
+
+    // Drop the cached instance so the next open re-reads from disk.
+    resetRunLogs();
+
+    const second = RunLog.open(session);
+    second.userPrompt('turn two');
+    second.runEnd({ totals: { inputTokens: 0, outputTokens: 0, cost: 0, toolCalls: 0, durationMs: 1 }, exitReason: 'completed' });
+    await second.flush();
+
+    const lines = readRunLog(runLogPath(session, RUNS_DIR));
+    expect(lines).toHaveLength(4);
+    expect(lines.map((l) => l.seq)).toEqual([0, 1, 2, 3]);
+    expect(verifyChain(lines).ok).toBe(true);
+  });
+
+  it('returns the same instance for repeated opens (shared chain)', () => {
+    const session = freshSession();
+    const a = RunLog.open(session);
+    const b = RunLog.open(session);
+    expect(a).toBe(b);
+  });
+
+  it('close() flushes and drops the instance from the cache', async () => {
+    const session = freshSession();
+    const a = RunLog.open(session);
+    a.userPrompt('hi');
+    await a.close();
+    // File was flushed.
+    expect(fs.existsSync(runLogPath(session, RUNS_DIR))).toBe(true);
+    // A fresh open after close is a new instance that resumes from disk.
+    const b = RunLog.open(session);
+    expect(b).not.toBe(a);
+    b.runEnd({ totals: { inputTokens: 0, outputTokens: 0, cost: 0, toolCalls: 0, durationMs: 1 }, exitReason: 'completed' });
+    await b.flush();
+    const lines = readRunLog(runLogPath(session, RUNS_DIR));
+    expect(lines.map((l) => l.seq)).toEqual([0, 1]);
+    expect(verifyChain(lines).ok).toBe(true);
+  });
+
+  it('resumes past a corrupt tail line via best-effort scan', async () => {
+    const session = freshSession();
+    const first = RunLog.open(session);
+    first.runStart({ session, cwd: '/tmp', provider: 'p', model: 'm', config: {} });
+    first.userPrompt('one');
+    await first.flush();
+
+    // Simulate a torn/garbage final line, then re-open.
+    fs.appendFileSync(runLogPath(session, RUNS_DIR), 'THIS IS NOT JSON\n');
+    resetRunLogs();
+
+    const second = RunLog.open(session);
+    second.runEnd({ totals: { inputTokens: 0, outputTokens: 0, cost: 0, toolCalls: 0, durationMs: 1 }, exitReason: 'completed' });
+    await second.flush();
+
+    // The parseable lines (skipping the garbage) form an intact chain, and the
+    // new event resumed from seq 2 (after the two valid lines).
+    const raw = fs.readFileSync(runLogPath(session, RUNS_DIR), 'utf-8').split('\n');
+    const valid: RunLogLine[] = [];
+    for (const line of raw) {
+      const t = line.trim();
+      if (!t) continue;
+      try { valid.push(JSON.parse(t) as RunLogLine); } catch { /* skip garbage */ }
+    }
+    expect(valid.map((l) => l.seq)).toEqual([0, 1, 2]);
+    expect(verifyChain(valid).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rotation
+// ---------------------------------------------------------------------------
+
+describe('rotateRuns', () => {
+  function makeFile(dir: string, name: string, mtimeSec: number): void {
+    const full = path.join(dir, name);
+    fs.writeFileSync(full, '{}\n');
+    fs.utimesSync(full, mtimeSec, mtimeSec);
+  }
+
+  it('keeps only the newest N files', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-rotate-'));
+    makeFile(dir, 'a.jsonl', 1000);
+    makeFile(dir, 'b.jsonl', 2000);
+    makeFile(dir, 'c.jsonl', 3000);
+    makeFile(dir, 'd.jsonl', 4000);
+    makeFile(dir, 'e.jsonl', 5000);
+
+    rotateRuns(dir, 3);
+
+    const remaining = fs.readdirSync(dir).filter((f) => f.endsWith('.jsonl')).sort();
+    expect(remaining).toEqual(['c.jsonl', 'd.jsonl', 'e.jsonl']);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('is a no-op when under the limit', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-rotate-'));
+    makeFile(dir, 'a.jsonl', 1000);
+    rotateRuns(dir, 100);
+    expect(fs.readdirSync(dir)).toHaveLength(1);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('prunes old sessions when a new one is opened', async () => {
+    // Seed 4 old traces with increasing mtimes in the default runs dir.
+    fs.mkdirSync(RUNS_DIR, { recursive: true });
+    for (let i = 0; i < 4; i++) {
+      const f = path.join(RUNS_DIR, `old_${i}.jsonl`);
+      fs.writeFileSync(f, '{}\n');
+      fs.utimesSync(f, 1000 + i, 1000 + i);
+    }
+    const session = freshSession();
+    RunLog.open(session, { retention: 2 }); // triggers rotateRuns before the new file
+    const files = fs.readdirSync(RUNS_DIR).filter((f) => f.startsWith('old_'));
+    expect(files.length).toBeLessThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reading + settings
+// ---------------------------------------------------------------------------
+
+describe('readRunLog', () => {
+  it('throws on an unparseable line', async () => {
+    const session = freshSession();
+    const file = runLogPath(session, RUNS_DIR);
+    fs.mkdirSync(RUNS_DIR, { recursive: true });
+    fs.writeFileSync(file, '{"v":1}\nnot json\n');
+    expect(() => readRunLog(file)).toThrow(/unparseable/);
+  });
+
+  it('skips blank lines', () => {
+    const session = freshSession();
+    const file = runLogPath(session, RUNS_DIR);
+    fs.mkdirSync(RUNS_DIR, { recursive: true });
+    fs.writeFileSync(file, '{"v":1,"seq":0}\n\n\n');
+    expect(readRunLog(file)).toHaveLength(1);
+  });
+});
+
+describe('resolveAuditSettings', () => {
+  it('is enabled by default with the tmp-home runs dir', () => {
+    const s = resolveAuditSettings();
+    expect(s.enabled).toBe(true);
+    expect(s.dir).toBe(RUNS_DIR);
+    expect(s.retention).toBe(100);
+  });
+
+  it('honours explicit overrides', () => {
+    const s = resolveAuditSettings({ enabled: false, dir: '/custom', retention: 5 });
+    expect(s).toEqual({ enabled: false, dir: '/custom', retention: 5 });
+  });
+
+  it('sanitizes path separators out of a session id (no traversal)', () => {
+    const p = runLogPath('../../etc/passwd', '/runs');
+    // Slashes (the traversal vector) are neutralized; the result stays in /runs.
+    expect(p).toBe(path.join('/runs', '.._.._etc_passwd.jsonl'));
+    expect(path.dirname(p)).toBe('/runs');
+  });
+});

--- a/tests/ui-loop-control.test.ts
+++ b/tests/ui-loop-control.test.ts
@@ -9,8 +9,10 @@ vi.mock('../src/config.js', () => ({
   default: {},
   get: vi.fn((key: string) => {
     if (key === 'maxIterations') return 1;
+    if (key === 'audit') return { enabled: false }; // no run-log disk writes in tests
     return undefined;
   }),
+  getConfig: vi.fn(() => ({})),
 }));
 
 vi.mock('../src/providers/index.js', () => ({


### PR DESCRIPTION
## Summary
- Replayable audit logs: JSONL per session with versioned schema, hash-chained lines, secret redaction (config snapshot + tool args), on by default, retention 100
- calliope replay: read-only chronological rendering with cost accumulation and chain verification; --json; exit 0/4
- Budget caps: per-run cost/tokens + per-project cost (persistent ledger); clean halt after the in-flight tool result; headless exit code 3; /status surfaces budget state
- Policy hook: config-pointed script, tool-call JSON on stdin, allow/deny by exit code, fail-closed on timeout/spawn error, policy_event audited either way — the Zentinelle seam, no dependency; existing pre-tool hook (already deny-capable via exit 42) untouched and runs first
- Zero bench impact: governance modules lazy-load off the gated paths; log writes async/buffered off the keystroke path

## Test Plan
- +78 mocked tests (runlog/budget/policy/replay/headless-governance): 3,667 passed, 4 skipped (105 files); coverage 94.2%
- npm run bench PASS (cold 94ms, keystroke p95 1.4ms, memory unchanged)

Fixes #189