### PR TITLE
Add baseline ACP agent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ One file, 16 keys. Credentials live in a per-provider map with environment-varia
 
 Docs: [getting started](docs/getting-started.md) · [commands](docs/commands.md) · [configuration](docs/configuration.md) · [providers](docs/providers.md) · [features](docs/features.md) · [fleet mode](docs/fleet.md)
 
+## Editors
+
+Run Calliope as an [Agent Client Protocol](https://agentclientprotocol.com) agent (`calliope acp`) inside Zed, JetBrains, Neovim, and other ACP editors — client-side file edits, per-tool permissions, and the same audit trail. See [docs/acp.md](docs/acp.md).
+
 ## Fleet mode
 
 Coordinate a fleet of agents and human operators over a self-hosted IRC channel that doubles as an audit trail. Off by default, zero cost when disabled. See [docs/fleet.md](docs/fleet.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ provider backends, and a small, tested command surface.
 - [Local models](./local-models.md) — how the harness adapts to self-hosted 7-70B models
 - [Features](./features.md) — the full v3 feature set (and what was removed)
 - [Governance](./governance.md) — audit run logs, replay, budget caps, policy hook
+- [Editors (ACP)](./acp.md) — run Calliope as an Agent Client Protocol agent in Zed, JetBrains, and more
 - [Fleet mode](./fleet.md) — optional multi-agent coordination over IRC
 
 ## Quick reference

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -1,0 +1,146 @@
+# Editors: Agent Client Protocol (ACP)
+
+Calliope can run as an [Agent Client Protocol](https://agentclientprotocol.com)
+agent, so ACP-speaking editors — [Zed](https://zed.dev), JetBrains IDEs, Neovim,
+and others — can drive it as a coding agent without any Calliope-specific plugin.
+One command, `calliope acp`, speaks JSON-RPC 2.0 over stdio.
+
+```bash
+calliope acp
+```
+
+The subcommand is not meant to be run by hand: the editor launches it, writes
+JSON-RPC to its stdin, and reads notifications from its stdout. **stdout carries
+the protocol; all logs go to stderr**, so nothing corrupts the stream.
+
+It reuses the same agent core as everything else in Calliope — the provider chat
+loop, the tool runtime, the pre-tool policy hook, and the audit run log — so an
+ACP session behaves like a headless or interactive session, just driven by your
+editor.
+
+## What works (baseline conformance)
+
+The [baseline ACP agent surface](https://agentclientprotocol.com/protocol/overview#agent)
+is implemented and tested against the official TypeScript SDK
+(`@zed-industries/agent-client-protocol`):
+
+| Method / flow | Status | Notes |
+|---|---|---|
+| `initialize` | ✅ | Negotiates protocol v1; advertises agent capabilities |
+| `authenticate` | ✅ | No-op — Calliope authenticates via locally-configured provider keys |
+| `session/new` | ✅ | One Calliope session per ACP session; the session id round-trips |
+| `session/prompt` | ✅ | Drives the agent loop (chat + tools) to a stop reason |
+| `session/cancel` | ✅ | Aborts the in-flight turn; returns `stopReason: cancelled` |
+| `session/update` (streaming) | ✅ | `agent_message_chunk`, `tool_call`, `tool_call_update` |
+| `session/request_permission` | ✅ | Asked for mutating/destructive tools (see below) |
+| `fs/read_text_file`, `fs/write_text_file` | ✅ | Preferred for file tools when the client advertises `fs` |
+
+### Capability matrix
+
+**Advertised by Calliope (agent):**
+
+| Capability | Value |
+|---|---|
+| `promptCapabilities.image` / `audio` / `embeddedContext` | `false` — text and resource links only |
+| `loadSession` | `false` — see *Not yet done* |
+| `authMethods` | `[]` — no authentication required |
+
+**Consumed from the client (editor):**
+
+| Client capability | Effect |
+|---|---|
+| `fs.readTextFile` | `read_file` / `edit_file` read the editor's buffer instead of disk |
+| `fs.writeTextFile` | `write_file` / `edit_file` write through the editor instead of disk |
+| `requestPermission` | Used to gate mutating tools; falls back to *deny* if unavailable |
+| `terminal` | Not used yet — Calliope runs shell tools itself |
+
+### Permissions
+
+Read-only tools (`read_file`, `list_files`, `glob`, `grep`, `web_search`,
+`think`) run without asking. Tools that mutate state or that Calliope's risk model
+flags for confirmation (`write_file`, `edit_file`, `shell`, `git`, `execute_code`,
+and any high/critical-risk command) trigger a `session/request_permission` call so
+your editor can prompt you. If the client can't handle a permission request, the
+non-interactive default is to **deny** the mutating tool (read-only tools still
+run).
+
+Two gates always run regardless of the permission outcome, because they are the
+hard guardrails: the **pre-tool hooks** and the external **policy hook** (the
+[Zentinelle](./governance.md) integration point). A deny from either is reported
+to the model as a failed tool call so it can adapt.
+
+### Client-side filesystem
+
+When your editor advertises the `fs` capability, Calliope routes `read_file`,
+`write_file`, and `edit_file` through the editor's `fs/read_text_file` and
+`fs/write_text_file` rather than touching local disk. This is the marquee ACP
+behavior: edits apply to the buffer you are actually looking at — including
+**unsaved changes** — instead of the last-saved bytes on disk. Without the `fs`
+capability, file tools use local disk as usual.
+
+### Audit
+
+Every ACP session writes the same tamper-evident audit run log as any other
+Calliope session, tagged `mode: acp` in its `run_start` event. Inspect one with
+`calliope replay <sessionId>` (see [governance](./governance.md)).
+
+## Configuring your editor
+
+The provider and model come from your Calliope config (`defaultProvider` /
+`defaultModel`) or the usual `*_API_KEY` environment variables — configure those
+first (`calliope --setup`), exactly as for interactive use.
+
+### Zed
+
+Add an agent server to your Zed `settings.json`. Point it at the `calliope`
+binary (or `node /absolute/path/to/dist/bin.js`) with the `acp` argument:
+
+```json
+{
+  "agent_servers": {
+    "Calliope": {
+      "command": "calliope",
+      "args": ["acp"],
+      "env": {
+        "ANTHROPIC_API_KEY": "sk-ant-..."
+      }
+    }
+  }
+}
+```
+
+Then pick **Calliope** from the agent panel's agent menu. See Zed's
+[External Agents](https://zed.dev/docs/ai/external-agents) docs.
+
+### JetBrains
+
+JetBrains IDEs speak ACP through the AI Assistant / external-agent integration.
+Register an external ACP agent with the command `calliope` and argument `acp`
+(and the provider key in the environment), then select Calliope as the agent.
+The exact settings path varies by IDE version; consult your IDE's ACP/external
+agent documentation.
+
+### Any ACP client
+
+Any client that can launch a stdio ACP agent works the same way: run the command
+`calliope acp` with a configured provider key in the environment.
+
+## Not yet done
+
+- **Registry listing.** Submitting Calliope to the public ACP agent registry is
+  deferred to a later release.
+- **`session/load`.** Resuming a previous session (the `loadSession` capability)
+  is not implemented; each `session/new` starts fresh.
+- **Session modes / model selection** (`session/set_mode`, `session/set_model`).
+- **MCP servers over ACP.** `session/new` accepts an `mcpServers` list; Calliope
+  ignores it for now and uses its own MCP configuration.
+- **Terminals, images, and audio** in prompts/tool calls.
+
+## Verification status
+
+Code-level conformance is tested against the official ACP TypeScript SDK: the
+handshake, session lifecycle, streaming updates, the permission round-trip (grant
+and deny), mid-prompt cancellation, and client-side filesystem delegation are all
+covered by in-process tests that drive the SDK's client against the agent
+(`tests/acp.test.ts`, `tests/acp-fs-delegate.test.ts`). A live editor smoke test
+in Zed and JetBrains is pending and tracked on the release checklist.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/sdk": "^0.104.1",
         "@google/generative-ai": "^0.24.1",
         "@inquirer/prompts": "^7.2.0",
+        "@zed-industries/agent-client-protocol": "^0.4.5",
         "conf": "^13.0.1",
         "ink": "^6.6.0",
         "openai": "^4.77.0",
@@ -1572,6 +1573,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@zed-industries/agent-client-protocol": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@zed-industries/agent-client-protocol/-/agent-client-protocol-0.4.5.tgz",
+      "integrity": "sha512-OwHKfu5AiKul/GSJilHg36+kOSV9eOl2eYnjR6tenAQDdraSnt22WFk0SDFTeuAANz1Gxkv+DTf7Hq32rvX7FQ==",
+      "deprecated": "This package has been renamed to @agentclientprotocol/sdk. Please migrate to continue receiving updates.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -3993,6 +4004,15 @@
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@anthropic-ai/sdk": "^0.104.1",
     "@google/generative-ai": "^0.24.1",
     "@inquirer/prompts": "^7.2.0",
+    "@zed-industries/agent-client-protocol": "^0.4.5",
     "conf": "^13.0.1",
     "ink": "^6.6.0",
     "openai": "^4.77.0",

--- a/src/acp.ts
+++ b/src/acp.ts
@@ -1,0 +1,674 @@
+/**
+ * Calliope CLI - Agent Client Protocol (ACP) agent mode.
+ *
+ * `calliope acp` speaks the Agent Client Protocol (https://agentclientprotocol.com)
+ * over stdio JSON-RPC, so editors that speak ACP (Zed, JetBrains, Neovim, …) can
+ * drive Calliope as a coding agent. This module is the adapter: it maps the ACP
+ * surface onto Calliope's existing agent core (the same provider `chat`, `TOOLS`,
+ * `executeTool`, governance and audit pieces the headless runner uses) — no forked
+ * agent logic.
+ *
+ * Baseline agent surface implemented: `initialize`, `authenticate`, `session/new`,
+ * `session/prompt`; `session/cancel`; streaming `session/update` notifications; and
+ * the `session/request_permission` flow. When the client advertises `fs`
+ * capabilities, file tools are routed through the client's `fs/read_text_file` and
+ * `fs/write_text_file` so edits land on the editor's (possibly unsaved) buffers.
+ *
+ * The protocol owns stdout/stdin; ALL diagnostics go to stderr (see {@link log}),
+ * so a stray `console.log` never corrupts the JSON-RPC stream. The whole module is
+ * lazy-loaded from bin.ts only for the `acp` subcommand, so it adds nothing to the
+ * default cold-start path.
+ */
+
+import * as path from 'node:path';
+import { Readable, Writable } from 'node:stream';
+import {
+  AgentSideConnection,
+  ndJsonStream,
+  RequestError,
+  PROTOCOL_VERSION,
+  type Agent,
+  type Stream,
+  type ClientCapabilities,
+  type ContentBlock,
+  type SessionNotification,
+  type ToolKind,
+  type InitializeRequest,
+  type InitializeResponse,
+  type NewSessionRequest,
+  type NewSessionResponse,
+  type AuthenticateResponse,
+  type PromptRequest,
+  type PromptResponse,
+  type CancelNotification,
+} from '@zed-industries/agent-client-protocol';
+
+import * as config from './config.js';
+import { chat, selectProvider } from './providers/index.js';
+import { TOOLS, executeTool, type FsDelegate } from './tools.js';
+import { DEFAULT_MODELS, calculateCost } from './types.js';
+import type { Message, LLMProvider, LLMResponse, ToolCall, ToolResult } from './types.js';
+import { getSystemPromptForProvider, isLocalBackend } from './local-model.js';
+import * as memory from './memory.js';
+import { resolveIterationLimit } from './iteration-limit.js';
+import { RunLog } from './runlog.js';
+import { evaluatePolicy, isPolicyEnabled } from './policy.js';
+import { assessToolRisk } from './risk.js';
+import { checkHooksAllow } from './hooks.js';
+
+// ============================================================================
+// Diagnostics — stderr only (stdout carries the protocol).
+// ============================================================================
+
+function log(message: string): void {
+  process.stderr.write(`[calliope-acp] ${message}\n`);
+}
+
+/** Chatty per-request trace, gated on CALLIOPE_DEBUG (matches the rest of the CLI). */
+function debug(message: string): void {
+  if (process.env.CALLIOPE_DEBUG === '1') log(message);
+}
+
+/**
+ * Best-effort human message from a thrown value. Handles Error instances and the
+ * bare `{ code, message, data }` JSON-RPC error object the SDK rejects with.
+ */
+function errMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'object' && err !== null && 'message' in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  return String(err);
+}
+
+// ============================================================================
+// Tool → permission / presentation mapping
+// ============================================================================
+
+/**
+ * Tools with side effects. These always route through the permission flow (and
+ * are denied under the non-interactive fallback), matching the headless runner's
+ * notion of a mutating tool.
+ */
+const MUTATING_TOOLS = new Set(['shell', 'write_file', 'edit_file', 'git', 'execute_code', 'configure']);
+
+/**
+ * Whether a tool call must ask the client for permission before running.
+ * Read-only tools (read_file, list_files, think, glob, grep, web_search) run
+ * silently; anything that mutates state or that Calliope's risk model flags for
+ * confirmation asks first.
+ */
+function toolNeedsPermission(toolCall: ToolCall): boolean {
+  if (MUTATING_TOOLS.has(toolCall.name)) return true;
+  return assessToolRisk(toolCall).requiresConfirmation;
+}
+
+/** Map a Calliope tool name to the ACP tool kind (drives client icons/UX). */
+function toolKind(name: string): ToolKind {
+  switch (name) {
+    case 'read_file':
+    case 'list_files':
+    case 'glob':
+    case 'grep':
+      return 'read';
+    case 'write_file':
+    case 'edit_file':
+      return 'edit';
+    case 'shell':
+    case 'execute_code':
+    case 'git':
+      return 'execute';
+    case 'web_search':
+    case 'web_fetch':
+      return 'fetch';
+    case 'think':
+    case 'create_plan':
+      return 'think';
+    default:
+      return 'other';
+  }
+}
+
+/** A short human-readable title for a tool call, e.g. `read_file: src/a.ts`. */
+function toolTitle(toolCall: ToolCall): string {
+  const a = toolCall.arguments as Record<string, unknown>;
+  const hint =
+    typeof a.path === 'string'
+      ? a.path
+      : typeof a.command === 'string'
+        ? a.command
+        : typeof a.pattern === 'string'
+          ? a.pattern
+          : typeof a.query === 'string'
+            ? a.query
+            : '';
+  return hint ? `${toolCall.name}: ${hint}` : toolCall.name;
+}
+
+/** Absolute file location(s) a tool touches, for the client's follow-along UI. */
+function toolLocations(toolCall: ToolCall, cwd: string): { path: string }[] | undefined {
+  const p = (toolCall.arguments as Record<string, unknown>).path;
+  if (typeof p !== 'string' || p.length === 0) return undefined;
+  return [{ path: path.isAbsolute(p) ? p : path.join(cwd, p) }];
+}
+
+/**
+ * Flatten an ACP prompt (content blocks) into the plain text Calliope's agent
+ * loop consumes. Baseline requires Text and ResourceLink; a resource link is
+ * surfaced as an `@uri` mention, and an embedded text resource is inlined.
+ */
+function promptToText(blocks: ContentBlock[]): string {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      parts.push(block.text);
+    } else if (block.type === 'resource_link') {
+      parts.push(`@${block.uri}`);
+    } else if (block.type === 'resource') {
+      const resource = block.resource as { text?: unknown; uri?: unknown };
+      if (typeof resource.text === 'string') {
+        parts.push(resource.text);
+      } else if (typeof resource.uri === 'string') {
+        parts.push(`@${resource.uri}`);
+      }
+    }
+    // image / audio blocks are not advertised in promptCapabilities; ignore.
+  }
+  return parts.join('\n');
+}
+
+// ============================================================================
+// Session state
+// ============================================================================
+
+interface AcpSession {
+  id: string;
+  cwd: string;
+  /** Configured provider passed to `chat` (may be 'auto'). */
+  provider: LLMProvider;
+  /** Resolved provider used for the system prompt, cost model, and local flag. */
+  resolvedProvider: LLMProvider;
+  /** Configured model, or '' to let the provider pick its default. */
+  model: string;
+  localBackend: boolean;
+  messages: Message[];
+  runlog: RunLog;
+  /** Set by session/cancel; checked cooperatively at every loop boundary. */
+  cancelled: boolean;
+  totals: { inputTokens: number; outputTokens: number; cost: number; toolCalls: number };
+  startedAt: number;
+}
+
+type GateResult =
+  | { decision: 'allow' }
+  | { decision: 'deny'; reason: string }
+  | { decision: 'cancelled' };
+
+// ============================================================================
+// The agent
+// ============================================================================
+
+class CalliopeAgent implements Agent {
+  private clientCapabilities: ClientCapabilities = {};
+  private readonly sessions = new Map<string, AcpSession>();
+  /** Tail of the outgoing write chain; awaited to flush notifications. */
+  private lastWrite: Promise<void> = Promise.resolve();
+
+  constructor(private readonly conn: AgentSideConnection) {}
+
+  // ---- ACP: initialize --------------------------------------------------
+
+  async initialize(params: InitializeRequest): Promise<InitializeResponse> {
+    this.clientCapabilities = params.clientCapabilities ?? {};
+    const requested = typeof params.protocolVersion === 'number' ? params.protocolVersion : PROTOCOL_VERSION;
+    // Negotiate down to the newest version we both support (we support 1).
+    const negotiated = requested >= 1 && requested <= PROTOCOL_VERSION ? requested : PROTOCOL_VERSION;
+    debug(
+      `initialize: client protocol v${requested} -> v${negotiated}; ` +
+        `fs=${JSON.stringify(this.clientCapabilities.fs ?? {})} terminal=${this.clientCapabilities.terminal ?? false}`,
+    );
+    return {
+      protocolVersion: negotiated,
+      agentCapabilities: {
+        // session/load, MCP-over-ACP, and modes are not implemented yet.
+        loadSession: false,
+        promptCapabilities: { image: false, audio: false, embeddedContext: false },
+      },
+      // Calliope authenticates via locally-configured provider keys, so no ACP
+      // auth method is required.
+      authMethods: [],
+    };
+  }
+
+  // ---- ACP: authenticate (no-op; no auth methods advertised) ------------
+
+  async authenticate(): Promise<AuthenticateResponse> {
+    return {};
+  }
+
+  // ---- ACP: session/new -------------------------------------------------
+
+  async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
+    const cwd = params.cwd || process.cwd();
+    const provider = (process.env.CALLIOPE_PROVIDER as LLMProvider) || config.get('defaultProvider');
+    const model = process.env.CALLIOPE_MODEL || config.get('defaultModel') || '';
+
+    // Resolve the provider so 'auto' picks a real backend for the system prompt,
+    // cost model, and local-backend flag (mirrors the headless runner). Fall back
+    // to the raw provider if selection throws (chat() surfaces the real error).
+    let resolvedProvider: LLMProvider;
+    try {
+      resolvedProvider = selectProvider(provider);
+    } catch {
+      resolvedProvider = provider;
+    }
+    const localBackend = isLocalBackend(resolvedProvider);
+    const costModel = model || DEFAULT_MODELS[resolvedProvider];
+
+    const sessionId = `acp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const runlog = RunLog.open(sessionId);
+    runlog.runStart({
+      session: sessionId,
+      cwd,
+      provider: resolvedProvider,
+      model: costModel,
+      config: config.getConfig() as unknown as Record<string, unknown>,
+      mode: 'acp',
+    });
+
+    const systemPrompt = getSystemPromptForProvider(resolvedProvider);
+    const memoryContext = memory.buildMemoryContext(cwd);
+    const fullPrompt = memoryContext.trim()
+      ? systemPrompt + '\n\n--- Project Context ---\n' + memoryContext
+      : systemPrompt;
+
+    this.sessions.set(sessionId, {
+      id: sessionId,
+      cwd,
+      provider,
+      resolvedProvider,
+      model,
+      localBackend,
+      messages: [{ role: 'system', content: fullPrompt }],
+      runlog,
+      cancelled: false,
+      totals: { inputTokens: 0, outputTokens: 0, cost: 0, toolCalls: 0 },
+      startedAt: Date.now(),
+    });
+    debug(`session/new: ${sessionId} cwd=${cwd} provider=${resolvedProvider} model=${costModel}`);
+    return { sessionId };
+  }
+
+  // ---- ACP: session/prompt ---------------------------------------------
+
+  async prompt(params: PromptRequest): Promise<PromptResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw RequestError.invalidParams({ error: `unknown session: ${params.sessionId}` });
+    }
+
+    // Each prompt is a fresh turn; clear any stale cancel from a prior turn.
+    session.cancelled = false;
+    const text = promptToText(params.prompt);
+    session.messages.push({ role: 'user', content: text });
+    session.runlog.userPrompt(text);
+    debug(`session/prompt: ${session.id} (${text.length} chars)`);
+
+    const stopReason = await this.runTurn(session);
+    await session.runlog.flush();
+    return { stopReason };
+  }
+
+  // ---- ACP: session/cancel (notification) -------------------------------
+
+  async cancel(params: CancelNotification): Promise<void> {
+    const session = this.sessions.get(params.sessionId);
+    if (session) {
+      session.cancelled = true;
+      debug(`session/cancel: ${params.sessionId}`);
+    }
+  }
+
+  // ---- The agent loop (ACP-flavoured mirror of the headless loop) --------
+
+  private async runTurn(session: AcpSession): Promise<PromptResponse['stopReason']> {
+    const maxIterations = resolveIterationLimit(config.get('maxIterations'));
+    const costModel = session.model || DEFAULT_MODELS[session.resolvedProvider];
+    let iteration = 0;
+
+    while (iteration < maxIterations) {
+      if (session.cancelled) return this.finishCancelled(session);
+      iteration++;
+
+      // Stream assistant text as agent_message_chunk deltas via the chat seam.
+      let streamedChars = 0;
+      const onToken = (token: string): void => {
+        if (!token) return;
+        streamedChars += token.length;
+        this.emit(session.id, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: token } });
+      };
+
+      let response: LLMResponse;
+      try {
+        response = await chat(session.provider, session.messages, TOOLS, session.model || undefined, onToken);
+      } catch (err) {
+        const msg = errMessage(err);
+        log(`chat error: ${msg}`);
+        session.runlog.assistantMessage({ content: `[error: ${msg}]`, tokens: { input: 0, output: 0 }, cost: 0 });
+        await session.runlog.flush();
+        throw RequestError.internalError({ error: msg });
+      }
+
+      // Audit + spend accounting (mirrors headless).
+      if (response.usage) {
+        const cost = calculateCost(costModel, response.usage.inputTokens, response.usage.outputTokens);
+        session.totals.inputTokens += response.usage.inputTokens;
+        session.totals.outputTokens += response.usage.outputTokens;
+        session.totals.cost += cost;
+        session.runlog.assistantMessage({
+          content: response.content,
+          tokens: { input: response.usage.inputTokens, output: response.usage.outputTokens },
+          cost,
+        });
+      } else {
+        session.runlog.assistantMessage({ content: response.content, tokens: { input: 0, output: 0 }, cost: 0 });
+      }
+
+      // Providers that don't stream: emit the assembled content once so the
+      // client still sees the assistant message.
+      if (streamedChars === 0 && response.content) {
+        this.emit(session.id, { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: response.content } });
+      }
+
+      if (session.cancelled) return this.finishCancelled(session);
+
+      if (response.toolCalls && response.toolCalls.length > 0) {
+        session.messages.push({ role: 'assistant', content: response.content, toolCalls: response.toolCalls });
+
+        for (const toolCall of response.toolCalls) {
+          if (session.cancelled) return this.finishCancelled(session);
+          const outcome = await this.runToolCall(session, toolCall);
+          if (outcome === 'cancelled') return this.finishCancelled(session);
+        }
+        continue; // next model turn
+      }
+
+      // No tool calls: this is the final assistant message → end of turn.
+      session.messages.push({ role: 'assistant', content: response.content });
+      await this.flush();
+      return response.finishReason === 'length' ? 'max_tokens' : 'end_turn';
+    }
+
+    // Exhausted the iteration budget.
+    await this.flush();
+    return 'max_turn_requests';
+  }
+
+  /** Flush pending notifications and return the cancelled stop reason. */
+  private async finishCancelled(session: AcpSession): Promise<PromptResponse['stopReason']> {
+    debug(`turn cancelled: ${session.id}`);
+    await this.flush();
+    return 'cancelled';
+  }
+
+  // ---- One tool call: announce → gate → execute → report ----------------
+
+  private async runToolCall(session: AcpSession, toolCall: ToolCall): Promise<'ok' | 'cancelled'> {
+    session.runlog.toolCall({ id: toolCall.id, name: toolCall.name, args: toolCall.arguments });
+    session.totals.toolCalls++;
+
+    // Announce the pending tool call.
+    await this.emit(session.id, {
+      sessionUpdate: 'tool_call',
+      toolCallId: toolCall.id,
+      title: toolTitle(toolCall),
+      kind: toolKind(toolCall.name),
+      status: 'pending',
+      rawInput: toolCall.arguments,
+      locations: toolLocations(toolCall, session.cwd),
+    });
+
+    // Permission + hard governance gates.
+    const gate = await this.gateToolCall(session, toolCall);
+    if (gate.decision === 'cancelled') {
+      await this.reportToolResult(session, toolCall.id, '[cancelled]', true);
+      session.runlog.toolResult({ id: toolCall.id, result: '[cancelled]', isError: true, durationMs: 0 });
+      session.messages.push({ role: 'tool', content: '[cancelled]', toolCallId: toolCall.id });
+      return 'cancelled';
+    }
+    if (gate.decision === 'deny') {
+      await this.reportToolResult(session, toolCall.id, gate.reason, true);
+      session.runlog.toolResult({ id: toolCall.id, result: gate.reason, isError: true, durationMs: 0 });
+      session.messages.push({ role: 'tool', content: gate.reason, toolCallId: toolCall.id });
+      return 'ok';
+    }
+
+    // Allowed: mark in-progress and execute through the shared tool runtime,
+    // preferring the client's filesystem when it advertised fs capabilities.
+    await this.emit(session.id, { sessionUpdate: 'tool_call_update', toolCallId: toolCall.id, status: 'in_progress' });
+
+    const started = Date.now();
+    let result: ToolResult;
+    try {
+      result = await executeTool(toolCall, session.cwd, 60000, undefined, {
+        appendAnchorHash: session.localBackend,
+        fs: this.clientFsDelegate(session.id),
+      });
+    } catch (err) {
+      result = {
+        toolCallId: toolCall.id,
+        result: `Error: ${errMessage(err)}`,
+        isError: true,
+      };
+    }
+    const durationMs = Date.now() - started;
+
+    session.runlog.toolResult({
+      id: toolCall.id,
+      result: result.result,
+      isError: result.isError || false,
+      durationMs,
+    });
+    await this.reportToolResult(session, toolCall.id, result.displayResult || result.result, result.isError || false, result.result);
+    session.messages.push({ role: 'tool', content: result.result, toolCallId: toolCall.id });
+    return 'ok';
+  }
+
+  /** Send a terminal (completed/failed) tool_call_update to the client. */
+  private reportToolResult(
+    session: AcpSession,
+    toolCallId: string,
+    text: string,
+    isError: boolean,
+    rawResult?: string,
+  ): Promise<void> {
+    return this.emit(session.id, {
+      sessionUpdate: 'tool_call_update',
+      toolCallId,
+      status: isError ? 'failed' : 'completed',
+      content: [{ type: 'content', content: { type: 'text', text } }],
+      rawOutput: { result: rawResult ?? text, isError },
+    });
+  }
+
+  // ---- Gates: permission, then the hard hooks -------------------------
+
+  private async gateToolCall(session: AcpSession, toolCall: ToolCall): Promise<GateResult> {
+    // 1. Permission via the client (only for mutating / confirm-worthy tools).
+    if (toolNeedsPermission(toolCall)) {
+      const permission = await this.requestPermission(session, toolCall);
+      if (permission === 'cancelled') return { decision: 'cancelled' };
+      if (permission === 'reject') return { decision: 'deny', reason: '[Permission denied by user]' };
+      // 'allow' falls through to the hard gates below.
+    }
+
+    // 2. Pre-tool hooks — the hard gate, runs regardless of permission (exit-42
+    //    veto contract; see hooks.ts / docs/governance.md).
+    const hookGate = await checkHooksAllow('pre-tool', { tool: toolCall.name, toolArgs: toolCall.arguments });
+    if (!hookGate.allowed) {
+      return { decision: 'deny', reason: `[Blocked by hook: ${hookGate.reason || 'no reason given'}]` };
+    }
+
+    // 3. Policy hook — the Zentinelle integration point (fail closed).
+    if (isPolicyEnabled()) {
+      const verdict = await evaluatePolicy(toolCall);
+      session.runlog.policyEvent({
+        tool: toolCall.name,
+        decision: verdict.decision,
+        source: verdict.source,
+        reason: verdict.reason,
+        durationMs: verdict.durationMs,
+      });
+      if (verdict.decision === 'deny') {
+        return { decision: 'deny', reason: `[Policy denied: ${verdict.reason || 'no reason given'}]` };
+      }
+    }
+
+    return { decision: 'allow' };
+  }
+
+  /**
+   * Ask the client to authorize a tool call. Returns the user's decision, or
+   * falls back to Calliope's non-interactive default (deny) when the client does
+   * not support the permission request at all.
+   */
+  private async requestPermission(session: AcpSession, toolCall: ToolCall): Promise<'allow' | 'reject' | 'cancelled'> {
+    try {
+      const res = await this.conn.requestPermission({
+        sessionId: session.id,
+        toolCall: {
+          toolCallId: toolCall.id,
+          title: toolTitle(toolCall),
+          kind: toolKind(toolCall.name),
+          rawInput: toolCall.arguments,
+        },
+        options: [
+          { optionId: 'allow', name: 'Allow', kind: 'allow_once' },
+          { optionId: 'allow_always', name: 'Always allow', kind: 'allow_always' },
+          { optionId: 'reject', name: 'Reject', kind: 'reject_once' },
+        ],
+      });
+      const outcome = res.outcome;
+      if (outcome.outcome === 'cancelled') return 'cancelled';
+      if (outcome.outcome === 'selected') return outcome.optionId.startsWith('allow') ? 'allow' : 'reject';
+      return 'reject';
+    } catch (err) {
+      // Client can't handle permission requests: non-interactive default is to
+      // deny anything that needed asking (read-only tools never reach here).
+      log(
+        `requestPermission unavailable (${errMessage(err)}); ` +
+          `denying ${toolCall.name} under the non-interactive default`,
+      );
+      return 'reject';
+    }
+  }
+
+  // ---- Client-side filesystem delegate ---------------------------------
+
+  /**
+   * Build an {@link FsDelegate} that routes file tool reads/writes through the
+   * client's `fs/read_text_file` / `fs/write_text_file`, but only for the
+   * capabilities the client advertised. Returns undefined when the client has no
+   * fs capability, so tools fall back to local disk.
+   */
+  private clientFsDelegate(sessionId: string): FsDelegate | undefined {
+    const fsCap = this.clientCapabilities.fs;
+    if (!fsCap || (!fsCap.readTextFile && !fsCap.writeTextFile)) return undefined;
+
+    const conn = this.conn;
+    const delegate: FsDelegate = {};
+    if (fsCap.readTextFile) {
+      delegate.readTextFile = async (absPath: string): Promise<string> => {
+        const res = await conn.readTextFile({ sessionId, path: absPath });
+        return res.content;
+      };
+    }
+    if (fsCap.writeTextFile) {
+      delegate.writeTextFile = async (absPath: string, content: string): Promise<void> => {
+        await conn.writeTextFile({ sessionId, path: absPath, content });
+      };
+    }
+    return delegate;
+  }
+
+  // ---- Notification plumbing -------------------------------------------
+
+  /**
+   * Send a session/update notification. Writes serialize in call order via the
+   * SDK's write queue, so the tail promise flushes everything before it. Errors
+   * are swallowed to stderr — a failed notification must never crash the loop.
+   */
+  private emit(sessionId: string, update: SessionNotification['update']): Promise<void> {
+    const p = this.conn.sessionUpdate({ sessionId, update }).catch((err) => {
+      log(`sessionUpdate failed: ${errMessage(err)}`);
+    });
+    this.lastWrite = p;
+    return p;
+  }
+
+  /** Await all pending outgoing notifications. */
+  private flush(): Promise<void> {
+    return this.lastWrite;
+  }
+
+  /** Close every session's audit log (best-effort) on shutdown. */
+  async shutdown(): Promise<void> {
+    for (const session of this.sessions.values()) {
+      session.runlog.runEnd({
+        totals: {
+          inputTokens: session.totals.inputTokens,
+          outputTokens: session.totals.outputTokens,
+          cost: session.totals.cost,
+          toolCalls: session.totals.toolCalls,
+          durationMs: Date.now() - session.startedAt,
+        },
+        exitReason: session.cancelled ? 'cancelled' : 'completed',
+      });
+      await session.runlog.close();
+    }
+  }
+}
+
+// ============================================================================
+// Entry points
+// ============================================================================
+
+/**
+ * Wire a {@link CalliopeAgent} onto an ACP {@link Stream}. Exposed for tests,
+ * which drive the SDK's client side against it over an in-memory stream pair.
+ * The SDK calls the factory synchronously, so the returned agent is ready.
+ */
+export function serveAcp(stream: Stream): CalliopeAgent {
+  let agent!: CalliopeAgent;
+  // eslint-disable-next-line no-new -- the connection registers itself and reads.
+  new AgentSideConnection((conn) => {
+    agent = new CalliopeAgent(conn);
+    return agent;
+  }, stream);
+  return agent;
+}
+
+/**
+ * Run Calliope as an ACP agent over stdio (stdout/stdin carry JSON-RPC). Started
+ * from bin.ts when argv[0] === 'acp'. Resolves when the client closes the stream.
+ */
+export async function runAcpAgent(): Promise<number> {
+  const input = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
+  const output = Writable.toWeb(process.stdout) as unknown as WritableStream<Uint8Array>;
+  const stream = ndJsonStream(output, input);
+  const agent = serveAcp(stream);
+  log(`Calliope ACP agent ready on stdio (protocol v${PROTOCOL_VERSION}). Logs go to stderr.`);
+
+  // Stay alive until the client disconnects (stdin closes).
+  await new Promise<void>((resolve) => {
+    const done = (): void => resolve();
+    process.stdin.on('end', done);
+    process.stdin.on('close', done);
+    process.stdin.on('error', done);
+  });
+
+  await agent.shutdown();
+  log('ACP client disconnected; shutting down.');
+  return 0;
+}

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -164,6 +164,17 @@ async function main(): Promise<void> {
     process.exit(code);
   }
 
+  // Handle `acp` subcommand — run as an Agent Client Protocol agent over stdio
+  // JSON-RPC (Zed, JetBrains, Neovim, …). Runs before the setup/TUI gates and
+  // never touches Ink: stdio carries the protocol, so an interactive prompt
+  // would corrupt it. The module (and the ACP SDK) is loaded lazily here so the
+  // default path pays nothing for it.
+  if (args[0] === 'acp') {
+    const { runAcpAgent } = await import('./acp.js');
+    const code = await runAcpAgent();
+    process.exit(code);
+  }
+
   // Handle --upgrade
   if (args.includes('--upgrade') || args.includes('-u')) {
     const current = getVersion();
@@ -303,6 +314,7 @@ ${bold('calliope')} - Multi-model AI agent CLI
 ${bold('USAGE')}
   calliope [options] [prompt]
   calliope replay <path|sessionId> [--json]   Render an audit run-log trace
+  calliope acp                                 Run as an ACP agent over stdio (for editors)
 
 ${bold('OPTIONS')}
   -h, --help        Show this help message

--- a/src/runlog.ts
+++ b/src/runlog.ts
@@ -61,6 +61,8 @@ export interface RunStartPayload {
   model: string;
   /** Config snapshot with credentials stripped (never contains apiKey/token values). */
   config: Record<string, unknown>;
+  /** How the session was driven: e.g. 'headless', 'acp'. Omitted for the default TUI. */
+  mode?: string;
 }
 
 export interface AssistantMessagePayload {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -381,13 +381,30 @@ function validatePath(filePath: string, cwd: string): string {
 }
 
 /**
+ * A filesystem delegate that routes file reads/writes for the file tools
+ * (read_file / write_file / edit_file) through an external owner of the file
+ * rather than local disk. The marquee use is an ACP session preferring the
+ * editor's (possibly unsaved) buffers over what is on disk.
+ *
+ * Only the methods present are delegated; a missing method falls back to local
+ * fs, so a client that advertises only reads (or only writes) still works. The
+ * `absPath` passed in is already scope-validated and absolute.
+ */
+export interface FsDelegate {
+  readTextFile?(absPath: string): Promise<string>;
+  writeTextFile?(absPath: string, content: string): Promise<void>;
+}
+
+/**
  * Options that vary tool execution by the active backend without threading
  * provider identity through every call. `appendAnchorHash` makes read_file emit
  * the current content hash (local backends only) so the model can echo it back
- * on a subsequent anchored edit_file (feature 4).
+ * on a subsequent anchored edit_file (feature 4). `fs` routes file ops through a
+ * delegate (feature: ACP client-side filesystem).
  */
 export interface ExecuteToolOptions {
   appendAnchorHash?: boolean;
+  fs?: FsDelegate;
 }
 
 /**
@@ -428,7 +445,7 @@ export async function executeTool(
         if (typeof args.path !== 'string') {
           return { toolCallId: id, result: 'Error: path must be a string', isError: true };
         }
-        result = await readFile(args.path, cwd, options?.appendAnchorHash === true);
+        result = await readFile(args.path, cwd, options?.appendAnchorHash === true, options?.fs);
         break;
       }
 
@@ -439,7 +456,7 @@ export async function executeTool(
         if (typeof args.content !== 'string') {
           return { toolCallId: id, result: 'Error: content must be a string', isError: true };
         }
-        result = await writeFile(args.path, args.content, cwd);
+        result = await writeFile(args.path, args.content, cwd, options?.fs);
         break;
       }
 
@@ -629,7 +646,7 @@ export async function executeTool(
         // anchor_hash is optional and accepted from any caller; it is only
         // advertised in the simplified local schema (feature 4).
         const anchorHash = typeof args.anchor_hash === 'string' ? args.anchor_hash : undefined;
-        result = await editFile(args.path, args.old_string, args.new_string, replaceAll, cwd, anchorHash);
+        result = await editFile(args.path, args.old_string, args.new_string, replaceAll, cwd, anchorHash, options?.fs);
         break;
       }
 
@@ -974,24 +991,32 @@ async function executeShell(command: string, cwd: string, timeout: number, onOut
  * is appended so the model can echo it back on a subsequent anchored edit_file
  * (stale-view protection, feature 4).
  */
-async function readFile(filePath: string, cwd: string, appendAnchorHash = false): Promise<string> {
+async function readFile(filePath: string, cwd: string, appendAnchorHash = false, fsDelegate?: FsDelegate): Promise<string> {
   const absPath = validatePath(filePath, cwd);
 
-  if (!fs.existsSync(absPath)) {
-    throw new Error(`File not found: ${absPath}`);
-  }
+  let content: string;
+  if (fsDelegate?.readTextFile) {
+    // Client-side fs (e.g. an ACP editor buffer that may hold unsaved changes).
+    // The client owns existence/size; a missing file surfaces as a thrown error
+    // that executeTool turns into a normal tool error.
+    content = await fsDelegate.readTextFile(absPath);
+  } else {
+    if (!fs.existsSync(absPath)) {
+      throw new Error(`File not found: ${absPath}`);
+    }
 
-  const stats = fs.statSync(absPath);
-  if (stats.isDirectory()) {
-    throw new Error(`Path is a directory: ${absPath}`);
-  }
+    const stats = fs.statSync(absPath);
+    if (stats.isDirectory()) {
+      throw new Error(`Path is a directory: ${absPath}`);
+    }
 
-  // Check file size (limit to 1MB)
-  if (stats.size > 1024 * 1024) {
-    throw new Error(`File too large (${Math.round(stats.size / 1024)}KB). Max 1MB.`);
-  }
+    // Check file size (limit to 1MB)
+    if (stats.size > 1024 * 1024) {
+      throw new Error(`File too large (${Math.round(stats.size / 1024)}KB). Max 1MB.`);
+    }
 
-  const content = fs.readFileSync(absPath, 'utf-8');
+    content = fs.readFileSync(absPath, 'utf-8');
+  }
 
   // Inline file preview header (#119). The header carries the line count;
   // the full content follows once — no preview/footer, those duplicated the
@@ -1074,31 +1099,47 @@ function generateDiff(oldContent: string, newContent: string, maxLines = 20): st
 /**
  * Write a file
  */
-async function writeFile(filePath: string, content: string, cwd: string): Promise<string> {
+async function writeFile(filePath: string, content: string, cwd: string, fsDelegate?: FsDelegate): Promise<string> {
   const absPath = validatePath(filePath, cwd);
-
-  // Create directory if needed
-  const dir = path.dirname(absPath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
 
   // Read existing content for diff
   let oldContent = '';
   let isNewFile = true;
-  if (fs.existsSync(absPath)) {
-    try {
-      const stats = fs.statSync(absPath);
-      if (!stats.isDirectory() && stats.size < 100 * 1024) {
-        oldContent = fs.readFileSync(absPath, 'utf-8');
-        isNewFile = false;
-      }
-    } catch {
-      // Ignore errors reading old content
-    }
-  }
 
-  fs.writeFileSync(absPath, content);
+  if (fsDelegate?.writeTextFile) {
+    // Client-side fs: read the current buffer for the diff (absent = new file),
+    // then write through the client instead of touching local disk.
+    if (fsDelegate.readTextFile) {
+      try {
+        oldContent = await fsDelegate.readTextFile(absPath);
+        isNewFile = false;
+      } catch {
+        oldContent = '';
+        isNewFile = true;
+      }
+    }
+    await fsDelegate.writeTextFile(absPath, content);
+  } else {
+    // Create directory if needed
+    const dir = path.dirname(absPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    if (fs.existsSync(absPath)) {
+      try {
+        const stats = fs.statSync(absPath);
+        if (!stats.isDirectory() && stats.size < 100 * 1024) {
+          oldContent = fs.readFileSync(absPath, 'utf-8');
+          isNewFile = false;
+        }
+      } catch {
+        // Ignore errors reading old content
+      }
+    }
+
+    fs.writeFileSync(absPath, content);
+  }
 
   // Generate diff output (#119)
   const DIFF_CAP = 50;
@@ -1470,19 +1511,35 @@ async function editFile(
   replaceAll: boolean,
   cwd: string,
   anchorHash?: string,
+  fsDelegate?: FsDelegate,
 ): Promise<string> {
   const absPath = validatePath(filePath, cwd);
 
-  if (!fs.existsSync(absPath)) {
-    throw new Error(`File not found: ${absPath}`);
+  let content: string;
+  if (fsDelegate?.readTextFile) {
+    // Client-side fs: edit against the editor's current buffer, not disk.
+    content = await fsDelegate.readTextFile(absPath);
+  } else {
+    if (!fs.existsSync(absPath)) {
+      throw new Error(`File not found: ${absPath}`);
+    }
+
+    const stats = fs.statSync(absPath);
+    if (stats.isDirectory()) {
+      throw new Error(`Path is a directory: ${absPath}`);
+    }
+
+    content = fs.readFileSync(absPath, 'utf-8');
   }
 
-  const stats = fs.statSync(absPath);
-  if (stats.isDirectory()) {
-    throw new Error(`Path is a directory: ${absPath}`);
-  }
-
-  const content = fs.readFileSync(absPath, 'utf-8');
+  // Persist the edited content through the delegate when available, else disk.
+  const writeUpdated = async (updated: string): Promise<void> => {
+    if (fsDelegate?.writeTextFile) {
+      await fsDelegate.writeTextFile(absPath, updated);
+    } else {
+      fs.writeFileSync(absPath, updated);
+    }
+  };
 
   // Stale-view protection (feature 4): if the caller supplied an anchor_hash, it
   // must match the file's current content. A mismatch means the model is acting
@@ -1532,7 +1589,7 @@ async function editFile(
     if (count === 0) {
       throw new Error(`old_string not found in file: ${absPath}`);
     }
-    fs.writeFileSync(absPath, updated);
+    await writeUpdated(updated);
     return buildEditDiff(oldString, newString, filePath, count);
   }
 
@@ -1548,7 +1605,7 @@ async function editFile(
   }
 
   const updated = content.replace(oldString, newString);
-  fs.writeFileSync(absPath, updated);
+  await writeUpdated(updated);
   return buildEditDiff(oldString, newString, filePath, 1);
 }
 

--- a/tests/acp-fs-delegate.test.ts
+++ b/tests/acp-fs-delegate.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the FsDelegate seam in src/tools.ts (#190).
+ *
+ * These exercise the REAL executeTool / read_file / write_file / edit_file against
+ * a delegate — proving that when a filesystem delegate is supplied (the seam an
+ * ACP session uses to prefer the editor's unsaved buffers), file ops route
+ * through it instead of local disk, and fall back to disk when it is absent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { executeTool, type FsDelegate } from '../src/tools.js';
+import { resetScope } from '../src/scope.js';
+import type { ToolCall } from '../src/types.js';
+
+let tmpDir: string;
+
+function tool(name: string, args: Record<string, unknown>): ToolCall {
+  return { id: `call-${Math.random().toString(36).slice(2)}`, name, arguments: args };
+}
+
+/** An in-memory "editor buffer" filesystem keyed by absolute path. */
+function bufferFs(initial: Record<string, string> = {}): {
+  delegate: Required<FsDelegate>;
+  buffers: Map<string, string>;
+  reads: string[];
+  writes: { path: string; content: string }[];
+} {
+  const buffers = new Map(Object.entries(initial));
+  const reads: string[] = [];
+  const writes: { path: string; content: string }[] = [];
+  const delegate: Required<FsDelegate> = {
+    async readTextFile(absPath) {
+      reads.push(absPath);
+      if (!buffers.has(absPath)) throw new Error(`buffer miss: ${absPath}`);
+      return buffers.get(absPath)!;
+    },
+    async writeTextFile(absPath, content) {
+      writes.push({ path: absPath, content });
+      buffers.set(absPath, content);
+    },
+  };
+  return { delegate, buffers, reads, writes };
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-acpfs-test-'));
+  resetScope(tmpDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('read_file fs delegation', () => {
+  it('prefers the delegate buffer over what is on disk', async () => {
+    const abs = path.join(tmpDir, 'note.txt');
+    fs.writeFileSync(abs, 'DISK CONTENT');
+    const { delegate, reads } = bufferFs({ [abs]: 'BUFFER CONTENT' });
+
+    const res = await executeTool(tool('read_file', { path: 'note.txt' }), tmpDir, 60000, undefined, { fs: delegate });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.result).toContain('BUFFER CONTENT');
+    expect(res.result).not.toContain('DISK CONTENT');
+    expect(reads).toContain(abs);
+  });
+
+  it('falls back to local disk when no delegate is supplied', async () => {
+    const abs = path.join(tmpDir, 'note.txt');
+    fs.writeFileSync(abs, 'DISK CONTENT');
+
+    const res = await executeTool(tool('read_file', { path: 'note.txt' }), tmpDir);
+
+    expect(res.result).toContain('DISK CONTENT');
+  });
+
+  it('surfaces a delegate read error as a normal tool error', async () => {
+    const { delegate } = bufferFs(); // buffer empty → read throws
+    const res = await executeTool(tool('read_file', { path: 'missing.txt' }), tmpDir, 60000, undefined, { fs: delegate });
+    expect(res.isError).toBe(true);
+    expect(res.result).toContain('buffer miss');
+  });
+});
+
+describe('write_file fs delegation', () => {
+  it('writes through the delegate and does NOT touch local disk', async () => {
+    const abs = path.join(tmpDir, 'out.txt');
+    const { delegate, writes, buffers } = bufferFs();
+
+    const res = await executeTool(
+      tool('write_file', { path: 'out.txt', content: 'hello buffer' }),
+      tmpDir,
+      60000,
+      undefined,
+      { fs: delegate },
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(writes).toEqual([{ path: abs, content: 'hello buffer' }]);
+    expect(buffers.get(abs)).toBe('hello buffer');
+    // The marquee behaviour: local disk is untouched when delegated.
+    expect(fs.existsSync(abs)).toBe(false);
+  });
+
+  it('diffs against the delegate buffer for an existing file', async () => {
+    const abs = path.join(tmpDir, 'out.txt');
+    const { delegate } = bufferFs({ [abs]: 'old line\n' });
+
+    const res = await executeTool(
+      tool('write_file', { path: 'out.txt', content: 'new line\n' }),
+      tmpDir,
+      60000,
+      undefined,
+      { fs: delegate },
+    );
+
+    expect(res.isError).toBeFalsy();
+    // Existing file → a real diff, not a "new file" banner.
+    expect(res.result).not.toContain('new file');
+  });
+
+  it('falls back to local disk when no delegate is supplied', async () => {
+    const abs = path.join(tmpDir, 'out.txt');
+    await executeTool(tool('write_file', { path: 'out.txt', content: 'on disk' }), tmpDir);
+    expect(fs.readFileSync(abs, 'utf-8')).toBe('on disk');
+  });
+});
+
+describe('edit_file fs delegation', () => {
+  it('edits the delegate buffer and writes back through it', async () => {
+    const abs = path.join(tmpDir, 'code.ts');
+    fs.writeFileSync(abs, 'const x = 1;\n'); // disk differs from buffer
+    const { delegate, writes, buffers } = bufferFs({ [abs]: 'const x = 999;\n' });
+
+    const res = await executeTool(
+      tool('edit_file', { path: 'code.ts', old_string: 'const x = 999;', new_string: 'const x = 42;' }),
+      tmpDir,
+      60000,
+      undefined,
+      { fs: delegate },
+    );
+
+    expect(res.isError).toBeFalsy();
+    expect(buffers.get(abs)).toBe('const x = 42;\n');
+    expect(writes).toHaveLength(1);
+    // Local disk (which held the un-buffered `const x = 1;`) is untouched.
+    expect(fs.readFileSync(abs, 'utf-8')).toBe('const x = 1;\n');
+  });
+
+  it('errors when the old_string is not in the delegate buffer', async () => {
+    const abs = path.join(tmpDir, 'code.ts');
+    const { delegate } = bufferFs({ [abs]: 'const x = 1;\n' });
+    const res = await executeTool(
+      tool('edit_file', { path: 'code.ts', old_string: 'not present', new_string: 'y' }),
+      tmpDir,
+      60000,
+      undefined,
+      { fs: delegate },
+    );
+    expect(res.isError).toBe(true);
+    expect(res.result).toContain('old_string not found');
+  });
+});

--- a/tests/acp.test.ts
+++ b/tests/acp.test.ts
@@ -1,0 +1,591 @@
+/**
+ * ACP agent conformance tests (#190).
+ *
+ * Drives the official ACP SDK's ClientSideConnection against Calliope's
+ * `serveAcp` agent over an in-memory duplex stream pair — fully in-process, no
+ * editor, no subprocess. The provider (`chat`) and tool runtime (`executeTool`)
+ * are mocked so turns are deterministic; the SDK's real JSON-RPC plumbing,
+ * capability negotiation, session lifecycle, permission flow, and zod validation
+ * of every notification are exercised for real.
+ *
+ * os.homedir is redirected to a temp dir so the audit run log lands under tmp.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { tmpHome } = vi.hoisted(() => {
+  const _fs = require('fs') as typeof import('fs');
+  const _path = require('path') as typeof import('path');
+  const _os = require('os') as typeof import('os');
+  const dir = _fs.mkdtempSync(_path.join(_os.tmpdir(), 'calliope-acp-test-'));
+  return { tmpHome: dir };
+});
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => tmpHome };
+});
+
+vi.mock('../src/config.js', () => ({
+  default: {},
+  get: vi.fn((key: string) => {
+    if (key === 'maxIterations') return 10;
+    if (key === 'defaultProvider') return 'anthropic';
+    if (key === 'defaultModel') return 'claude-sonnet-4-6';
+    // audit / policy / hooks all default (undefined) → audit on, policy off.
+    return undefined;
+  }),
+  getConfig: vi.fn(() => ({ defaultProvider: 'anthropic' })),
+}));
+
+const mockChat = vi.fn();
+const mockExecuteTool = vi.fn();
+
+vi.mock('../src/providers/index.js', () => ({
+  chat: (...args: unknown[]) => mockChat(...args),
+  selectProvider: (p: string) => (p && p !== 'auto' ? p : 'anthropic'),
+}));
+
+vi.mock('../src/tools.js', () => ({
+  TOOLS: [],
+  executeTool: (...args: unknown[]) => mockExecuteTool(...args),
+  getTools: vi.fn(() => []),
+}));
+
+vi.mock('../src/memory.js', () => ({ buildMemoryContext: vi.fn(() => '') }));
+
+vi.mock('../src/local-model.js', () => ({
+  getSystemPromptForProvider: vi.fn(() => 'system'),
+  isLocalBackend: vi.fn(() => false),
+}));
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  ClientSideConnection,
+  type Client,
+  type Agent,
+  type Stream,
+  type SessionNotification,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type ReadTextFileRequest,
+  type ReadTextFileResponse,
+  type WriteTextFileRequest,
+  type ClientCapabilities,
+} from '@zed-industries/agent-client-protocol';
+import { serveAcp } from '../src/acp.js';
+import { readRunLog, verifyChain, resetRunLogs, type RunLogLine } from '../src/runlog.js';
+import type { ToolCall } from '../src/types.js';
+
+const RUNS_DIR = path.join(tmpHome, '.calliope-cli', 'runs');
+
+// ---------------------------------------------------------------------------
+// In-memory transport + test client
+// ---------------------------------------------------------------------------
+
+/** A pair of AnyMessage-level streams wired agent<->client (no byte encoding). */
+function streamPair(): { agentStream: Stream; clientStream: Stream } {
+  const a2c = new TransformStream();
+  const c2a = new TransformStream();
+  return {
+    agentStream: { readable: c2a.readable as Stream['readable'], writable: a2c.writable as Stream['writable'] },
+    clientStream: { readable: a2c.readable as Stream['readable'], writable: c2a.writable as Stream['writable'] },
+  };
+}
+
+class TestClient implements Client {
+  updates: SessionNotification[] = [];
+  permissionRequests: RequestPermissionRequest[] = [];
+  /** How to answer a permission request; default: allow once. */
+  permissionResponder: (req: RequestPermissionRequest) => RequestPermissionResponse = () => ({
+    outcome: { outcome: 'selected', optionId: 'allow' },
+  });
+  /** Editor buffers for fs delegation, keyed by absolute path. */
+  buffers = new Map<string, string>();
+  fsReads: string[] = [];
+  fsWrites: { path: string; content: string }[] = [];
+
+  async sessionUpdate(params: SessionNotification): Promise<void> {
+    this.updates.push(params);
+  }
+  async requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
+    this.permissionRequests.push(params);
+    return this.permissionResponder(params);
+  }
+  async readTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
+    this.fsReads.push(params.path);
+    if (!this.buffers.has(params.path)) throw new Error(`no buffer for ${params.path}`);
+    return { content: this.buffers.get(params.path)! };
+  }
+  async writeTextFile(params: WriteTextFileRequest): Promise<Record<string, never>> {
+    this.fsWrites.push({ path: params.path, content: params.content });
+    this.buffers.set(params.path, params.content);
+    return {};
+  }
+
+  updatesOf(type: string): SessionNotification['update'][] {
+    return this.updates.filter((u) => u.update.sessionUpdate === type).map((u) => u.update);
+  }
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+async function settle(times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) await tick();
+}
+async function waitFor(cond: () => boolean, tries = 200): Promise<void> {
+  for (let i = 0; i < tries; i++) {
+    if (cond()) return;
+    await tick();
+  }
+  throw new Error('waitFor: condition never became true');
+}
+
+/** Spin up an agent + connected test client over an in-memory pair. */
+function connect(): { client: TestClient; conn: ClientSideConnection; agent: ReturnType<typeof serveAcp> } {
+  const { agentStream, clientStream } = streamPair();
+  const agent = serveAcp(agentStream);
+  const client = new TestClient();
+  const conn = new ClientSideConnection((_agent: Agent) => client, clientStream);
+  return { client, conn, agent };
+}
+
+async function handshake(
+  conn: ClientSideConnection,
+  clientCapabilities: ClientCapabilities = {},
+): Promise<void> {
+  await conn.initialize({ protocolVersion: 1, clientCapabilities });
+}
+
+async function newSession(conn: ClientSideConnection, cwd = tmpHome): Promise<string> {
+  const res = await conn.newSession({ cwd, mcpServers: [] });
+  return res.sessionId;
+}
+
+// A scripted chat response.
+interface ChatStep {
+  stream?: string[];
+  content?: string;
+  toolCalls?: ToolCall[];
+  finishReason?: string;
+}
+
+function scriptChat(steps: ChatStep[]): void {
+  let i = 0;
+  mockChat.mockImplementation(async (_p: unknown, _m: unknown, _t: unknown, _model: unknown, onToken?: (t: string) => void) => {
+    const step = steps[Math.min(i, steps.length - 1)];
+    i++;
+    if (step.stream && onToken) for (const t of step.stream) onToken(t);
+    return {
+      content: step.content ?? (step.stream ? step.stream.join('') : ''),
+      toolCalls: step.toolCalls ?? [],
+      finishReason: step.finishReason ?? (step.toolCalls?.length ? 'tool_use' : 'stop'),
+      usage: { inputTokens: 7, outputTokens: 3 },
+    };
+  });
+}
+
+beforeEach(() => {
+  mockChat.mockReset();
+  mockExecuteTool.mockReset();
+  mockExecuteTool.mockResolvedValue({ toolCallId: 't', result: 'ok', isError: false });
+  resetRunLogs();
+});
+
+afterEach(() => {
+  fs.rmSync(RUNS_DIR, { recursive: true, force: true });
+});
+
+// ===========================================================================
+// initialize / capability negotiation
+// ===========================================================================
+
+describe('initialize', () => {
+  it('negotiates protocol v1 and advertises the baseline capabilities', async () => {
+    const { conn } = connect();
+    const res = await conn.initialize({ protocolVersion: 1, clientCapabilities: {} });
+
+    expect(res.protocolVersion).toBe(1);
+    expect(res.agentCapabilities?.loadSession).toBe(false);
+    expect(res.agentCapabilities?.promptCapabilities).toEqual({ image: false, audio: false, embeddedContext: false });
+    expect(res.authMethods).toEqual([]);
+  });
+
+  it('clamps an unsupported (newer) protocol version down to what it supports', async () => {
+    const { conn } = connect();
+    const res = await conn.initialize({ protocolVersion: 99, clientCapabilities: {} });
+    expect(res.protocolVersion).toBe(1);
+  });
+});
+
+// ===========================================================================
+// session/new + session/prompt happy path
+// ===========================================================================
+
+describe('session/new + session/prompt', () => {
+  it('creates a session whose id round-trips and drives a text + tool-call turn', async () => {
+    const { client, conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+    expect(sessionId).toMatch(/^acp_/);
+
+    mockExecuteTool.mockResolvedValue({ toolCallId: 'c1', result: 'FILE BODY', isError: false });
+    scriptChat([
+      { toolCalls: [{ id: 'c1', name: 'read_file', arguments: { path: 'a.txt' } }] },
+      { stream: ['All ', 'done'] },
+    ]);
+
+    const res = await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'read a.txt' }] });
+    await settle();
+
+    expect(res.stopReason).toBe('end_turn');
+
+    // The tool ran (read_file is read-only → no permission needed).
+    expect(mockExecuteTool).toHaveBeenCalledTimes(1);
+    const toolCall = mockExecuteTool.mock.calls[0][0] as ToolCall;
+    expect(toolCall.name).toBe('read_file');
+
+    // A tool_call announcement, a completed update carrying the result, and the
+    // streamed assistant text all reached the client.
+    const toolCalls = client.updatesOf('tool_call');
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toMatchObject({ toolCallId: 'c1', title: 'read_file: a.txt', kind: 'read', status: 'pending' });
+
+    const completed = client.updatesOf('tool_call_update').find((u) => (u as { status?: string }).status === 'completed');
+    expect(JSON.stringify(completed)).toContain('FILE BODY');
+
+    const chunks = client.updatesOf('agent_message_chunk');
+    const streamed = chunks.map((c) => (c as { content: { text: string } }).content.text).join('');
+    expect(streamed).toBe('All done');
+  });
+
+  it('emits the session/update events in a sane order', async () => {
+    const { client, conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+
+    scriptChat([
+      { toolCalls: [{ id: 'c1', name: 'read_file', arguments: { path: 'a.txt' } }] },
+      { content: 'final' },
+    ]);
+
+    await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'go' }] });
+    await settle();
+
+    const seq = client.updates.map((u) => {
+      const up = u.update as { sessionUpdate: string; status?: string };
+      return up.status ? `${up.sessionUpdate}:${up.status}` : up.sessionUpdate;
+    });
+    expect(seq).toEqual([
+      'tool_call:pending',
+      'tool_call_update:in_progress',
+      'tool_call_update:completed',
+      'agent_message_chunk',
+    ]);
+  });
+
+  it('reports max_turn_requests when the iteration budget is exhausted', async () => {
+    const { conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+
+    // Always ask for another tool call → never terminates on its own.
+    scriptChat([{ toolCalls: [{ id: 'loop', name: 'read_file', arguments: { path: 'a.txt' } }] }]);
+
+    const res = await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'spin' }] });
+    expect(res.stopReason).toBe('max_turn_requests');
+  });
+});
+
+// ===========================================================================
+// permission flow
+// ===========================================================================
+
+describe('session/request_permission', () => {
+  it('asks for permission on a mutating tool and runs it when granted', async () => {
+    const { client, conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+
+    client.permissionResponder = () => ({ outcome: { outcome: 'selected', optionId: 'allow' } });
+    mockExecuteTool.mockResolvedValue({ toolCallId: 'w1', result: 'wrote', isError: false });
+    scriptChat([
+      { toolCalls: [{ id: 'w1', name: 'write_file', arguments: { path: 'out.txt', content: 'hi' } }] },
+      { content: 'done' },
+    ]);
+
+    const res = await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'write out.txt' }] });
+    await settle();
+
+    expect(res.stopReason).toBe('end_turn');
+    expect(client.permissionRequests).toHaveLength(1);
+    expect(client.permissionRequests[0].toolCall.toolCallId).toBe('w1');
+    expect(mockExecuteTool).toHaveBeenCalledTimes(1);
+    const completed = client.updatesOf('tool_call_update').find((u) => (u as { status?: string }).status === 'completed');
+    expect(completed).toBeDefined();
+  });
+
+  it('does NOT run the tool when permission is rejected', async () => {
+    const { client, conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+
+    client.permissionResponder = () => ({ outcome: { outcome: 'selected', optionId: 'reject' } });
+    scriptChat([
+      { toolCalls: [{ id: 'w1', name: 'write_file', arguments: { path: 'out.txt', content: 'hi' } }] },
+      { content: 'ok anyway' },
+    ]);
+
+    const res = await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'write out.txt' }] });
+    await settle();
+
+    expect(res.stopReason).toBe('end_turn');
+    expect(client.permissionRequests).toHaveLength(1);
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+    const failed = client.updatesOf('tool_call_update').find((u) => (u as { status?: string }).status === 'failed');
+    expect(JSON.stringify(failed)).toContain('Permission denied');
+  });
+
+  it('reads are allowed without asking for permission', async () => {
+    const { client, conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+
+    mockExecuteTool.mockResolvedValue({ toolCallId: 'r1', result: 'body', isError: false });
+    scriptChat([
+      { toolCalls: [{ id: 'r1', name: 'read_file', arguments: { path: 'a.txt' } }] },
+      { content: 'done' },
+    ]);
+
+    await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'read' }] });
+    await settle();
+
+    expect(client.permissionRequests).toHaveLength(0);
+    expect(mockExecuteTool).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ===========================================================================
+// session/cancel
+// ===========================================================================
+
+describe('session/cancel', () => {
+  it('aborts an in-flight turn and returns stopReason cancelled', async () => {
+    const { conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+
+    let started = false;
+    let release!: () => void;
+    const blocked = new Promise<void>((r) => {
+      release = r;
+    });
+    mockChat.mockImplementationOnce(async () => {
+      started = true;
+      await blocked;
+      return { content: 'too late', toolCalls: [], finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 } };
+    });
+
+    const promptPromise = conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'long task' }] });
+    await waitFor(() => started); // chat is now blocking mid-turn
+    await conn.cancel({ sessionId });
+    // The agent processes stream messages in order, so a request sent AFTER the
+    // cancel notification only resolves once the cancel was already handled —
+    // deterministic, no reliance on timer settling.
+    await conn.authenticate({ methodId: 'noop' });
+    release();
+
+    const res = await promptPromise;
+    expect(res.stopReason).toBe('cancelled');
+  });
+});
+
+// ===========================================================================
+// fs delegation threading (advertised vs not)
+// ===========================================================================
+
+describe('fs capability delegation', () => {
+  it('threads a client fs delegate into executeTool when fs is advertised', async () => {
+    const { conn } = connect();
+    await handshake(conn, { fs: { readTextFile: true, writeTextFile: true } });
+    const sessionId = await newSession(conn);
+
+    scriptChat([
+      { toolCalls: [{ id: 'r1', name: 'read_file', arguments: { path: 'a.txt' } }] },
+      { content: 'done' },
+    ]);
+    await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'read' }] });
+    await settle();
+
+    const opts = mockExecuteTool.mock.calls[0][4] as { fs?: { readTextFile?: unknown; writeTextFile?: unknown } };
+    expect(opts.fs).toBeDefined();
+    expect(typeof opts.fs?.readTextFile).toBe('function');
+    expect(typeof opts.fs?.writeTextFile).toBe('function');
+  });
+
+  it('the threaded delegate actually calls back to the client filesystem', async () => {
+    const { client, conn } = connect();
+    await handshake(conn, { fs: { readTextFile: true, writeTextFile: true } });
+    const sessionId = await newSession(conn);
+    const abs = path.join(tmpHome, 'buf.txt');
+    client.buffers.set(abs, 'FROM EDITOR BUFFER');
+
+    // A real-ish executeTool that consults the supplied fs delegate.
+    mockExecuteTool.mockImplementation(async (tc: ToolCall, _cwd: string, _to: number, _o: unknown, options: { fs?: { readTextFile?: (p: string) => Promise<string> } }) => {
+      const content = await options.fs!.readTextFile!(abs);
+      return { toolCallId: tc.id, result: content, isError: false };
+    });
+    scriptChat([
+      { toolCalls: [{ id: 'r1', name: 'read_file', arguments: { path: 'buf.txt' } }] },
+      { content: 'done' },
+    ]);
+
+    await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'read buf' }] });
+    await settle();
+
+    expect(client.fsReads).toContain(abs);
+    const completed = client.updatesOf('tool_call_update').find((u) => (u as { status?: string }).status === 'completed');
+    expect(JSON.stringify(completed)).toContain('FROM EDITOR BUFFER');
+  });
+
+  it('passes no fs delegate when the client does not advertise fs', async () => {
+    const { conn } = connect();
+    await handshake(conn, {}); // no fs capability
+    const sessionId = await newSession(conn);
+
+    scriptChat([
+      { toolCalls: [{ id: 'r1', name: 'read_file', arguments: { path: 'a.txt' } }] },
+      { content: 'done' },
+    ]);
+    await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'read' }] });
+    await settle();
+
+    const opts = mockExecuteTool.mock.calls[0][4] as { fs?: unknown };
+    expect(opts.fs).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// edge cases + lifecycle
+// ===========================================================================
+
+describe('edge cases', () => {
+  it('rejects a prompt for an unknown session', async () => {
+    const { conn } = connect();
+    await handshake(conn);
+    await expect(conn.prompt({ sessionId: 'nope', prompt: [{ type: 'text', text: 'hi' }] })).rejects.toThrow();
+  });
+
+  it('surfaces a provider error as a JSON-RPC error from prompt', async () => {
+    const { conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+    mockChat.mockRejectedValueOnce(new Error('provider exploded'));
+    await expect(conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'go' }] })).rejects.toThrow();
+  });
+
+  it('maps a length finish reason to stopReason max_tokens', async () => {
+    const { conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+    scriptChat([{ content: 'truncated', finishReason: 'length' }]);
+    const res = await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'go' }] });
+    expect(res.stopReason).toBe('max_tokens');
+  });
+
+  it('flattens resource_link and embedded resource blocks into the prompt text', async () => {
+    const { conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+    let captured: { role: string; content: string }[] = [];
+    mockChat.mockImplementation(async (_p: unknown, messages: { role: string; content: string }[]) => {
+      captured = messages;
+      return { content: 'ok', toolCalls: [], finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 } };
+    });
+    await conn.prompt({
+      sessionId,
+      prompt: [
+        { type: 'text', text: 'look at' },
+        { type: 'resource_link', uri: 'file:///x.ts', name: 'x.ts' },
+        { type: 'resource', resource: { uri: 'file:///y.ts', text: 'inline body', mimeType: 'text/plain' } },
+      ],
+    });
+    const userMsg = captured.find((m) => m.role === 'user');
+    expect(userMsg?.content).toContain('look at');
+    expect(userMsg?.content).toContain('@file:///x.ts');
+    expect(userMsg?.content).toContain('inline body');
+  });
+
+  it('denies a mutating tool when the client cannot handle permission requests', async () => {
+    const { client, conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+    client.permissionResponder = () => {
+      throw new Error('permission not supported');
+    };
+    scriptChat([
+      { toolCalls: [{ id: 'w1', name: 'write_file', arguments: { path: 'out.txt', content: 'x' } }] },
+      { content: 'moving on' },
+    ]);
+    const res = await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'write' }] });
+    await settle();
+    expect(res.stopReason).toBe('end_turn');
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+  });
+
+  it('treats a cancelled permission outcome as turn cancellation', async () => {
+    const { client, conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+    client.permissionResponder = () => ({ outcome: { outcome: 'cancelled' } });
+    scriptChat([{ toolCalls: [{ id: 'w1', name: 'write_file', arguments: { path: 'o.txt', content: 'x' } }] }]);
+    const res = await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'write' }] });
+    expect(res.stopReason).toBe('cancelled');
+    expect(mockExecuteTool).not.toHaveBeenCalled();
+  });
+
+  it('shutdown() closes the audit trace with a run_end', async () => {
+    const { conn, agent } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+    scriptChat([{ content: 'done' }]);
+    await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'go' }] });
+    await settle();
+    await agent.shutdown();
+
+    const lines = readRunLog(path.join(RUNS_DIR, `${sessionId}.jsonl`));
+    expect(lines.some((l) => l.type === 'run_end')).toBe(true);
+    expect(verifyChain(lines).ok).toBe(true);
+  });
+});
+
+// ===========================================================================
+// audit trail
+// ===========================================================================
+
+describe('audit run log', () => {
+  it('writes an audit trace tagged mode: acp with a valid hash chain', async () => {
+    const { conn } = connect();
+    await handshake(conn);
+    const sessionId = await newSession(conn);
+
+    mockExecuteTool.mockResolvedValue({ toolCallId: 'c1', result: 'body', isError: false });
+    scriptChat([
+      { toolCalls: [{ id: 'c1', name: 'read_file', arguments: { path: 'a.txt' } }] },
+      { content: 'done' },
+    ]);
+    await conn.prompt({ sessionId, prompt: [{ type: 'text', text: 'read a.txt' }] });
+    await settle();
+
+    const file = path.join(RUNS_DIR, `${sessionId}.jsonl`);
+    const lines: RunLogLine[] = readRunLog(file);
+
+    const runStart = lines.find((l) => l.type === 'run_start');
+    expect(runStart).toBeDefined();
+    expect((runStart as { mode?: string }).mode).toBe('acp');
+    expect(lines.some((l) => l.type === 'user_prompt')).toBe(true);
+    expect(lines.some((l) => l.type === 'tool_call')).toBe(true);
+    expect(lines.some((l) => l.type === 'tool_result')).toBe(true);
+    expect(verifyChain(lines).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- calliope acp: stdio JSON-RPC agent using @zed-industries/agent-client-protocol v0.4.5; baseline surface complete (initialize, authenticate, session/new, session/prompt, session/cancel, session/update streaming, permission round-trips)
- Marquee ACP behavior works: when the editor advertises fs capability, read/write/edit operate on editor buffers (unsaved changes visible), else local disk — via an FsDelegate seam in tools.ts, no ACP knowledge inside tools
- Governance applies in ACP sessions: pre-tool hooks + policy gate always run; audit runlog records mode: acp
- 28 in-memory protocol tests driving the SDK's ClientSideConnection against our agent (no subprocess, no editor needed); deterministic cancel via stream-ordered follow-up
- Lazy dispatch in bin.ts — bench PASS, cold start unchanged (92ms median)
- Deferred (documented in docs/acp.md): registry listing, session/load, modes, budget caps in ACP; live Zed/JetBrains smoke goes on Leo's checklist. Note: the SDK package is deprecated in favor of @agentclientprotocol/sdk — migration is a v3.1 line item

## Test Plan
- npm test: 3,695 passed, 4 skipped (107 files); coverage 93.9% (floor 90)
- npm run bench PASS

Fixes #190