### PR TITLE
Expand fleet docs: ergo setup, operator flows, dual audit trails

### DIFF
--- a/docs/fleet.md
+++ b/docs/fleet.md
@@ -33,13 +33,52 @@ Connection settings are read from, in order:
 Any IRC server works; [ergo](https://ergo.chat/) is a good self-hosted
 choice for private deployments (single binary, TLS, always-on history).
 
+### Minimal ergo setup
+
+```bash
+# 1. Run ergo (single static binary, or docker)
+docker run -d --name ergo -p 6697:6697 -v ergo-data:/ircd ghcr.io/ergochat/ergo:stable
+
+# 2. Point the relay at it
+cat > ~/.config/scuttlebot-relay.env <<CONF
+IRC_ADDR=your-host:6697
+IRC_TLS=true
+CONF
+
+# 3. Pick a channel per project
+echo "channel: myproject-fleet" > .scuttlebot.yaml
+
+# 4. In a calliope session
+/fleet enable
+```
+
+Ergo's `history` and `chathistory` settings give the channel durable,
+replayable history — operators who join late see the full trail.
+
 ## Operator flow
 
-Each connected agent joins with a unique nick and announces itself. An
-operator in the channel can address an agent by nick to inject an
-instruction; if the agent is mid-task the instruction is queued and runs
-next, otherwise it runs immediately. Agent replies and tool activity are
-mirrored to the channel prefixed by the agent's nick.
+Each connected agent joins with a unique nick and announces itself
+("connected — address me as: <nick>"). From there:
+
+- **Observe**: every user prompt, assistant reply, and tool call is
+  mirrored to the channel as it happens (secrets redacted), prefixed by
+  the agent's nick. Multiple agents in one channel interleave into a
+  single operational timeline.
+- **Intervene**: address an agent by nick to inject an instruction. If
+  the agent is mid-task the instruction queues and runs next; otherwise
+  it runs immediately.
+- **Coordinate**: agents on different machines/repos join the same
+  channel — the operator steers the fleet from one place, and agents can
+  see each other's traffic when addressed.
+
+## Two audit trails
+
+Fleet mode complements the local audit log (`docs/governance.md`): the
+runlog is the tamper-evident per-session record on the agent's machine
+(`calliope replay <sessionId>` to verify and re-render), while the IRC
+channel is the live, human-watchable fleet-level record that survives on
+the server. Private deployments get both without any third-party
+service.
 
 ## Scope
 


### PR DESCRIPTION
## Summary
- docs/fleet.md: 49 → 88 lines — minimal ergo deployment block (docker + relay env + per-project channel), observe/intervene/coordinate operator flows, and the dual-audit-trail story tying fleet channels to #189's tamper-evident runlog
- Verified: README positions fleet as a flagged power feature of the private-AI story; repo-wide grep finds zero remote-control claims attached to fleet/scuttlebot (only explicit disclaimers)
- Docs-only change

## Test Plan
- npm run build clean; docs-only, no behavior change

Fixes #191