### PR TITLE
Fix test-suite config wipe and silent provider/model fallbacks

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -100,9 +100,35 @@ const DEFAULT_CONFIG: CalliopeConfig = {
   sessionLogLimit: 0,  // Unlimited by default; set > 0 to cap retained session log items
 };
 
+/**
+ * Resolve the directory conf stores `config.json` in, and hard-guard tests.
+ *
+ * `CALLIOPE_CONFIG_DIR` overrides conf's default per-OS config location (conf's
+ * `cwd` option). It is the single seam that lets the test suite point every
+ * config read/write at a throwaway directory instead of the user's real store.
+ *
+ * The guard is the safety net behind #217: the config test suite calls
+ * `resetConfig()` (conf's `clear()`) in beforeEach/afterEach, and under the old
+ * default path that wiped the developer's real store on every run. Under Vitest
+ * we therefore REFUSE to open the real store unless the isolation setup
+ * (tests/setup/isolate-stores.ts) has pointed CALLIOPE_CONFIG_DIR at a temp dir.
+ * Exported so the guard is unit-testable without spawning a subprocess.
+ *
+ * Outside tests with the override unset it returns `undefined`, which conf
+ * treats as "use the env-paths default" (a falsy `cwd` is ignored by conf).
+ */
+export function resolveConfigCwd(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const dir = env.CALLIOPE_CONFIG_DIR;
+  if (env.VITEST && !dir) {
+    throw new Error('tests must set CALLIOPE_CONFIG_DIR — refusing to touch the real config store');
+  }
+  return dir || undefined;
+}
+
 // Create config store
 const config = new Conf<CalliopeConfig>({
   projectName: 'calliope',
+  cwd: resolveConfigCwd(),
   defaults: DEFAULT_CONFIG,
   schema: {
     setupComplete: { type: 'boolean' },
@@ -212,6 +238,17 @@ export function setProviderCred(provider: string, patch: ProviderCred): void {
   }
   all[provider] = merged;
   config.set('providers', all);
+}
+
+/**
+ * The credential environment variable(s) a provider reads, surfaced in the
+ * "how to fix" hint when an explicitly-selected provider has no credential
+ * (see providers/index.ts ProviderUnavailableError). `region`/`profile` arrays
+ * are intentionally omitted — only the primary apiKey/baseUrl var is a hint.
+ */
+export function getProviderEnvVars(provider: string): { apiKey?: string; baseUrl?: string } {
+  const env = PROVIDER_ENV[provider] ?? {};
+  return { apiKey: env.apiKey, baseUrl: env.baseUrl };
 }
 
 /**

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -7,7 +7,7 @@
  */
 
 import * as config from './config.js';
-import { chat, selectProvider } from './providers/index.js';
+import { chat, selectProvider, ProviderUnavailableError } from './providers/index.js';
 import { TOOLS, executeTool, getTools } from './tools.js';
 import { DEFAULT_MODELS, calculateCost } from './types.js';
 import { getSystemPromptForProvider, isLocalBackend } from './local-model.js';
@@ -168,12 +168,20 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
   }
 
   // Resolve the provider so 'auto' picks up a local backend correctly, then
-  // select the compact-vs-full system prompt for it (feature 5). Falls back to
-  // the raw provider if selection would throw (chat() surfaces the real error).
+  // select the compact-vs-full system prompt for it (feature 5).
+  //
+  // An explicitly-requested-but-unconfigured provider is a hard, actionable
+  // failure: print the fix to stderr and exit 2 rather than silently switching
+  // providers (#217). 'auto'-with-no-keys throws a plain Error instead — keep
+  // the old lenient fallback so chat() below surfaces that as a normal error.
   let resolvedProvider: LLMProvider;
   try {
     resolvedProvider = selectProvider(provider);
-  } catch {
+  } catch (err) {
+    if (err instanceof ProviderUnavailableError) {
+      emit({ type: 'error', timestamp: now(), data: { message: err.message } }, outputMode);
+      return 2;
+    }
     resolvedProvider = provider;
   }
   const localBackend = isLocalBackend(resolvedProvider);
@@ -196,8 +204,8 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
     timestamp: now(),
     data: {
       message: 'Starting headless session',
-      provider: selectProvider(provider),
-      model: model || DEFAULT_MODELS[selectProvider(provider)],
+      provider: resolvedProvider,
+      model: model || DEFAULT_MODELS[resolvedProvider],
     },
   }, outputMode);
 
@@ -213,6 +221,9 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
   let runOutputTokens = 0;
   let runCostUsd = 0;
   let runToolCalls = 0;
+  // Provider warnings (e.g. Ollama model substitution) surface as status events,
+  // deduped so a repeated substitution across iterations isn't emitted twice.
+  const seenWarnings = new Set<string>();
 
   runlog.runStart({
     session: sessionId,
@@ -253,6 +264,15 @@ export async function runHeadless(options: HeadlessOptions): Promise<number> {
       iteration++;
 
       const response = await chat(provider, messages, TOOLS, model);
+
+      // Surface provider warnings (model substitution, etc.) without hiding them.
+      if (response.warnings) {
+        for (const warning of response.warnings) {
+          if (seenWarnings.has(warning)) continue;
+          seenWarnings.add(warning);
+          emit({ type: 'status', timestamp: now(), data: { message: warning } }, outputMode);
+        }
+      }
 
       // Accumulate spend, persist it to the project ledger, and audit it.
       if (response.usage) {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -41,7 +41,50 @@ export function getAvailableProviders(): LLMProvider[] {
 }
 
 /**
- * Select the best available provider
+ * Thrown by selectProvider when an explicitly-chosen provider (i.e. not 'auto')
+ * has no usable credential. Carries the provider plus a message listing concrete
+ * fix steps. Exported so callers can catch it and surface the fix rather than
+ * crash or silently switch to a different provider (#217).
+ */
+export class ProviderUnavailableError extends Error {
+  readonly provider: LLMProvider;
+  constructor(provider: LLMProvider, message: string) {
+    super(message);
+    this.name = 'ProviderUnavailableError';
+    this.provider = provider;
+  }
+}
+
+/** Join fix clauses as "a, b, or c" (Oxford-style, single element passes through). */
+function joinFixes(parts: string[]): string {
+  if (parts.length <= 1) return parts.join('');
+  return `${parts.slice(0, -1).join(', ')}, or ${parts[parts.length - 1]}`;
+}
+
+/** Build the actionable "how to fix" message for an unconfigured provider. */
+function unavailableMessage(provider: LLMProvider): string {
+  const { apiKey, baseUrl } = config.getProviderEnvVars(provider);
+  if (provider === 'ollama' || provider === 'litellm') {
+    const fixes = ['calliope --setup', `/config set providers.${provider}.baseUrl <url>`];
+    if (baseUrl) fixes.push(`export ${baseUrl}`);
+    return `${provider} is selected but has no base URL. Fix: ${joinFixes(fixes)}.`;
+  }
+  if (provider === 'bedrock') {
+    const fixes = ['calliope --setup', 'set AWS_PROFILE or AWS_ACCESS_KEY_ID', '/config set providers.bedrock.apiKey <key>'];
+    return `bedrock is selected but has no AWS credentials. Fix: ${joinFixes(fixes)}.`;
+  }
+  const fixes = ['calliope --setup', `/config set providers.${provider}.apiKey <key>`];
+  if (apiKey) fixes.push(`export ${apiKey}`);
+  return `${provider} is selected but has no API key. Fix: ${joinFixes(fixes)}.`;
+}
+
+/**
+ * Select the provider to serve a request.
+ *
+ * An explicit provider ('anthropic', 'openai', …) is honored only if it has a
+ * usable credential; otherwise this throws ProviderUnavailableError rather than
+ * silently falling through to a different provider (#217). Only 'auto' walks the
+ * priority list and falls back.
  */
 export function selectProvider(preferred: LLMProvider): LLMProvider {
   if (preferred !== 'auto') {
@@ -54,6 +97,8 @@ export function selectProvider(preferred: LLMProvider): LLMProvider {
       const key = config.getApiKey(preferred);
       if (key) return preferred;
     }
+    // Explicitly requested but unconfigured: never silently switch providers.
+    throw new ProviderUnavailableError(preferred, unavailableMessage(preferred));
   }
 
   // Auto-select: prefer Anthropic > OpenAI > Google > others

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -424,5 +424,9 @@ async function tryFallback(
   }
 
   debugLog(`Ollama model "${originalModel}" not found, falling back to "${fallback}"`);
-  return doChat(baseUrl, fallback, messages, tools, onToken);
+  // Substituting the model is a decision the user must see, not a silent swap
+  // (#217): attach a warning the TUI/headless surface, don't hide it.
+  const warning = `ollama: model "${originalModel}" not found — using "${fallback}" (ollama pull ${originalModel} to use it)`;
+  const response = await doChat(baseUrl, fallback, messages, tools, onToken);
+  return { ...response, warnings: [warning, ...(response.warnings ?? [])] };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,9 @@ export interface LLMResponse {
     inputTokens: number;
     outputTokens: number;
   };
+  // Non-fatal notices the caller must surface, never swallow (#217). Example:
+  // Ollama substituting a fallback model when the requested one isn't pulled.
+  warnings?: string[];
 }
 
 // Default model per provider. This is the OFFLINE EMERGENCY FALLBACK only —

--- a/src/ui/agent.ts
+++ b/src/ui/agent.ts
@@ -278,6 +278,26 @@ async function maybeRepairLocalToolCalls(
 }
 
 // ============================================================================
+// Provider warnings
+// ============================================================================
+
+// Provider warnings already surfaced this process, keyed by sessionId::warning,
+// so a repeated model substitution across turns/iterations isn't shown twice
+// (#217). Non-fatal notices must be surfaced, never swallowed.
+const surfacedWarnings = new Set<string>();
+
+function surfaceResponseWarnings(ctx: AgentContext, response: LLMResponse): void {
+  if (!response.warnings?.length) return;
+  const sessionId = ctx.sessionRef.current?.id ?? 'session_adhoc';
+  for (const warning of response.warnings) {
+    const key = `${sessionId}::${warning}`;
+    if (surfacedWarnings.has(key)) continue;
+    surfacedWarnings.add(key);
+    ctx.addMessage('system', warning);
+  }
+}
+
+// ============================================================================
 // Run Agent
 // ============================================================================
 
@@ -505,6 +525,10 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
       // before it surfaces as an execution error (features 2 & 3). No-op for
       // cloud providers and well-formed responses.
       response = await maybeRepairLocalToolCalls(ctx, validatedMessages, response, effectiveModel, repairedCallIds);
+
+      // Surface provider warnings (e.g. Ollama model substitution) once per
+      // unique message per session — never swallow them (#217).
+      surfaceResponseWarnings(ctx, response);
 
       // Update token stats and cost
       if (response.usage) {

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -10,8 +10,9 @@ import { useEffect } from 'react';
 import type { MutableRefObject } from 'react';
 import { render, Box } from 'ink';
 import * as config from '../config.js';
-import { selectProvider } from '../providers/index.js';
+import { selectProvider, ProviderUnavailableError } from '../providers/index.js';
 import { DEFAULT_MODELS } from '../types.js';
+import type { LLMProvider } from '../types.js';
 import { getVersion } from '../version-check.js';
 import { getCurrentSkin, paletteColorize } from '../hud/api.js';
 import { renderColoredBanner, renderSplashAnimation, renderTransition, colorFg } from '../terminal-image.js';
@@ -77,7 +78,18 @@ function App() {
 
 // Print banner before Ink takes over (stays fixed at top)
 export async function printBanner(): Promise<void> {
-  const provider = selectProvider(config.get('defaultProvider'));
+  const requested = config.get('defaultProvider');
+  // Never claim a provider that won't serve (#217). If the selected provider is
+  // unconfigured, show the real selection annotated as such rather than
+  // crashing the banner or pretending a working provider.
+  let provider: LLMProvider;
+  let providerNote = '';
+  try {
+    provider = selectProvider(requested);
+  } catch (err) {
+    provider = err instanceof ProviderUnavailableError ? err.provider : requested;
+    providerNote = ' (not configured — run calliope --setup)';
+  }
   const model = config.get('defaultModel') || DEFAULT_MODELS[provider];
   const skin = getCurrentSkin();
 
@@ -132,7 +144,7 @@ export async function printBanner(): Promise<void> {
     }
   }
 
-  console.log(`${dim}  v${getVersion()} | ${provider}:${model}${reset}`);
+  console.log(`${dim}  v${getVersion()} | ${provider}:${model}${providerNote}${reset}`);
   console.log(`${dim}  /help for commands | ESC to exit${reset}`);
   console.log();
 }

--- a/src/ui/state/use-chat-controller.ts
+++ b/src/ui/state/use-chat-controller.ts
@@ -11,7 +11,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useApp } from 'ink';
 import * as config from '../../config.js';
-import { selectProvider } from '../../providers/index.js';
+import { selectProvider, ProviderUnavailableError } from '../../providers/index.js';
 import { DEFAULT_MODELS, supportsVision } from '../../types.js';
 import { getSystemPromptForProvider } from '../../local-model.js';
 import type { Message as LLMMessage, LLMProvider, Mode, MessageContent } from '../../types.js';
@@ -102,6 +102,7 @@ export function useChatController(): ChatController {
 
   // -- Long-lived refs ------------------------------------------------------
   const isProcessingRef = useRef(false);
+  const surfacedProviderErrorRef = useRef<string | null>(null);
   const inputSubmitRef = useRef<((value: string) => void) | null>(null);
   const openProviderPickerRef = useRef<(() => void) | null>(null);
   const sessionRef = useRef<storage.Session | null>(null);
@@ -119,11 +120,31 @@ export function useChatController(): ChatController {
   useEffect(() => { isProcessingRef.current = isProcessing; }, [isProcessing]);
 
   // -- Derived --------------------------------------------------------------
-  const actualProvider = selectProvider(provider);
+  // Resolve the true serving provider. An explicitly-selected provider with no
+  // credential must NOT silently fall back (#217): keep the status bar honest
+  // (show the real, unconfigured selection — not a provider that won't serve)
+  // and surface the fix once, keeping the UI alive so the user can /setup or
+  // /config set. 'auto' with no keys degrades to 'auto' for display.
+  let actualProvider: LLMProvider;
+  let providerErrorMessage: string | undefined;
+  try {
+    actualProvider = selectProvider(provider);
+  } catch (err) {
+    providerErrorMessage = err instanceof Error ? err.message : String(err);
+    actualProvider = err instanceof ProviderUnavailableError ? err.provider : 'auto';
+  }
   const actualModel = model || DEFAULT_MODELS[actualProvider];
   const isModalActive = modal.modalMode !== 'none';
   const contextPercentage = Math.round((stats.contextTokens / getModelContextLimit(actualProvider, actualModel)) * 100);
   const resolvedBreakerHealth = config.get('circuitBreakersEnabled') !== false ? breakerHealth : undefined;
+
+  // Surface a provider-credential problem once per unique message (per session).
+  useEffect(() => {
+    if (providerErrorMessage && surfacedProviderErrorRef.current !== providerErrorMessage) {
+      surfacedProviderErrorRef.current = providerErrorMessage;
+      addMessage('system', `⚠️ ${providerErrorMessage}`);
+    }
+  }, [providerErrorMessage, addMessage]);
 
   // -- Core helpers ---------------------------------------------------------
   const handleEditQueuedMessage = useCallback((index: number, newMsg: string) => {

--- a/tests/agent-repair.test.ts
+++ b/tests/agent-repair.test.ts
@@ -263,4 +263,17 @@ describe('local-backend tool-call repair loop', () => {
     expect(executeToolMock).toHaveBeenCalledTimes(1);
     expect(ctx.collectedMessages.some(sys('Malformed tool call'))).toBe(false);
   });
+
+  it('surfaces a provider warning (e.g. Ollama model substitution) to the transcript once (#217)', async () => {
+    // A warning string unique to this test so the per-session dedup Set (module
+    // scope) can't have been primed by another case.
+    const warning = 'ollama: model "unique-probe:99b" not found — using "llama3.2" (ollama pull unique-probe:99b to use it)';
+    chatMock.mockResolvedValueOnce({ content: 'done', toolCalls: [], finishReason: 'stop', warnings: [warning] });
+
+    const ctx = makeCtx();
+    await runAgentImpl(ctx, 'hello');
+
+    const surfaced = ctx.collectedMessages.filter(m => m.type === 'system' && m.content === warning);
+    expect(surfaced).toHaveLength(1);
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -23,6 +23,7 @@ import config, {
   setProviderCred,
   setMultiple,
   migrateV3,
+  resolveConfigCwd,
 } from '../src/config.js';
 
 // Seed a legacy (non-schema) key directly on the underlying conf store, bypassing
@@ -473,6 +474,38 @@ describe('getBaseUrl - bedrock', () => {
   it('should fall back to nested config baseUrl', () => {
     setProviderCred('bedrock', { baseUrl: 'https://bedrock.us-west-2.amazonaws.com' });
     expect(getBaseUrl('bedrock')).toBe('https://bedrock.us-west-2.amazonaws.com');
+  });
+});
+
+// ===========================================================================
+// resolveConfigCwd — the test-isolation guard (#217)
+// ===========================================================================
+
+describe('resolveConfigCwd (test-store isolation guard)', () => {
+  it('throws under Vitest when CALLIOPE_CONFIG_DIR is unset (refuses the real store)', () => {
+    expect(() => resolveConfigCwd({ VITEST: 'true' } as NodeJS.ProcessEnv))
+      .toThrow('tests must set CALLIOPE_CONFIG_DIR — refusing to touch the real config store');
+  });
+
+  it('returns the override dir when both VITEST and CALLIOPE_CONFIG_DIR are set', () => {
+    expect(resolveConfigCwd({ VITEST: 'true', CALLIOPE_CONFIG_DIR: '/tmp/iso' } as NodeJS.ProcessEnv))
+      .toBe('/tmp/iso');
+  });
+
+  it('returns undefined outside tests when the override is unset (conf uses its default)', () => {
+    expect(resolveConfigCwd({} as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+
+  it('honors the override even outside Vitest', () => {
+    expect(resolveConfigCwd({ CALLIOPE_CONFIG_DIR: '/tmp/prod-override' } as NodeJS.ProcessEnv))
+      .toBe('/tmp/prod-override');
+  });
+
+  it('the live process is isolated — the guard did not throw at import (dir is set)', () => {
+    // The vitest setup (tests/setup/isolate-stores.ts) must have set the override,
+    // otherwise importing config.ts would have thrown before this suite ran.
+    expect(process.env.CALLIOPE_CONFIG_DIR).toBeTruthy();
+    expect(resolveConfigCwd()).toBe(process.env.CALLIOPE_CONFIG_DIR);
   });
 });
 

--- a/tests/headless-provider-unavailable.test.ts
+++ b/tests/headless-provider-unavailable.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Headless must treat an explicitly-selected-but-unconfigured provider as a
+ * hard, actionable failure — print the fix to stderr and exit 2 — rather than
+ * silently switching providers (#217).
+ *
+ * The providers mock defines its own ProviderUnavailableError and exports it;
+ * headless.ts imports the same class from the same (mocked) module, so its
+ * `instanceof` check matches.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../src/config.js', () => ({
+  default: {},
+  get: vi.fn((key: string) => {
+    if (key === 'maxIterations') return 10;
+    if (key === 'audit') return { enabled: false };
+    return undefined;
+  }),
+  getConfig: vi.fn(() => ({})),
+  getApiKey: vi.fn(),
+  getBaseUrl: vi.fn(),
+  getConfiguredProviders: vi.fn(() => []),
+}));
+
+const mockChat = vi.fn();
+
+vi.mock('../src/providers/index.js', () => {
+  class ProviderUnavailableError extends Error {
+    provider: string;
+    constructor(provider: string, message: string) {
+      super(message);
+      this.name = 'ProviderUnavailableError';
+      this.provider = provider;
+    }
+  }
+  return {
+    chat: (...args: unknown[]) => mockChat(...args),
+    selectProvider: (p: string) => {
+      throw new ProviderUnavailableError(
+        p,
+        `${p} is selected but has no API key. Fix: calliope --setup, /config set providers.${p}.apiKey <key>, or export ${p.toUpperCase()}_API_KEY.`,
+      );
+    },
+    ProviderUnavailableError,
+  };
+});
+
+vi.mock('../src/tools.js', () => ({ TOOLS: [], executeTool: vi.fn(), getTools: vi.fn(() => []) }));
+vi.mock('../src/types.js', () => ({
+  getSystemPrompt: vi.fn(() => 'You are a helpful assistant.'),
+  DEFAULT_MODELS: { openai: 'gpt-4o', anthropic: 'claude-3-5-sonnet-20241022' },
+  calculateCost: vi.fn(() => 0),
+}));
+vi.mock('../src/memory.js', () => ({ buildMemoryContext: vi.fn(() => '') }));
+
+import { runHeadless } from '../src/headless.js';
+
+let stderrWrite: typeof process.stderr.write;
+let stdoutWrite: typeof process.stdout.write;
+const stderrChunks: string[] = [];
+beforeEach(() => {
+  mockChat.mockReset();
+  stderrChunks.length = 0;
+  stderrWrite = process.stderr.write.bind(process.stderr);
+  stdoutWrite = process.stdout.write.bind(process.stdout);
+  process.stderr.write = vi.fn((c: unknown) => { stderrChunks.push(String(c)); return true; }) as unknown as typeof process.stderr.write;
+  process.stdout.write = vi.fn(() => true) as unknown as typeof process.stdout.write;
+});
+afterEach(() => {
+  process.stderr.write = stderrWrite;
+  process.stdout.write = stdoutWrite;
+});
+
+describe('headless — provider unavailable (#217)', () => {
+  it('exits 2 and prints the fix, without ever calling chat', async () => {
+    const code = await runHeadless({ prompt: 'hello', provider: 'openai', outputMode: 'text', maxRetries: 0 });
+
+    expect(code).toBe(2);
+    // The error carried the actionable fix hint...
+    const err = stderrChunks.join('');
+    expect(err).toContain('openai is selected but has no API key');
+    expect(err).toContain('calliope --setup');
+    // ...and we never fell through to a provider call.
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+});

--- a/tests/headless-retry.test.ts
+++ b/tests/headless-retry.test.ts
@@ -182,3 +182,31 @@ describe('headless retry budget', () => {
     expect(stderrCalls.some((s: string) => s.includes('[retry'))).toBe(false);
   });
 });
+
+describe('headless surfaces provider warnings (#217)', () => {
+  const stderrLines = () => (process.stderr.write as ReturnType<typeof vi.fn>).mock.calls
+    .map((c: unknown[]) => String(c[0]));
+
+  it('emits a provider warning (model substitution) as a status event, not silence', async () => {
+    const warning = 'ollama: model "devstral:24b" not found — using "llama3.2" (ollama pull devstral:24b to use it)';
+    mockChat.mockResolvedValueOnce({ content: 'done', toolCalls: [], warnings: [warning] });
+
+    const code = await runHeadless({ prompt: 'hello', outputMode: 'text', maxRetries: 0 });
+
+    expect(code).toBe(0);
+    expect(stderrLines().some((s) => s.includes('STATUS:') && s.includes(warning))).toBe(true);
+  });
+
+  it('deduplicates a repeated warning across iterations (surfaced once)', async () => {
+    const warning = 'ollama: model "x:7b" not found — using "y" (ollama pull x:7b to use it)';
+    mockChat
+      .mockResolvedValueOnce({ content: '', toolCalls: [{ id: 't1', name: 'read_file', arguments: {} }], warnings: [warning] })
+      .mockResolvedValueOnce({ content: 'done', toolCalls: [], warnings: [warning] });
+    mockExecuteTool.mockResolvedValueOnce({ result: 'ok', isError: false });
+
+    await runHeadless({ prompt: 'hello', outputMode: 'text', maxRetries: 0 });
+
+    const warnLines = stderrLines().filter((s) => s.includes('STATUS:') && s.includes(warning));
+    expect(warnLines).toHaveLength(1);
+  });
+});

--- a/tests/ollama.test.ts
+++ b/tests/ollama.test.ts
@@ -913,6 +913,27 @@ describe('chatOllama', () => {
       // Tools should still be passed through
       expect(fallbackBody.tools).toBeDefined();
     });
+
+    it('surfaces the substitution as a warning instead of swapping models silently (#217)', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(mockFetchResponse(
+        { error: 'model not found' },
+        false,
+        404
+      ) as Response);
+      vi.mocked(getOllamaFallbackModel).mockResolvedValueOnce('llama3.2:latest');
+      vi.mocked(fetch).mockResolvedValueOnce(mockFetchResponse(makeResponse()) as Response);
+
+      const result = await chatOllama(
+        [{ role: 'user', content: 'Hi' }],
+        [sampleTool],
+        'devstral:24b'
+      );
+
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings).toContain(
+        'ollama: model "devstral:24b" not found — using "llama3.2:latest" (ollama pull devstral:24b to use it)'
+      );
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/tests/provider-selection.test.ts
+++ b/tests/provider-selection.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for selectProvider's no-silent-switch behavior (#217).
+ *
+ * An explicitly-selected provider ('anthropic', 'openai', …) with no credential
+ * must throw ProviderUnavailableError carrying an actionable fix hint — it must
+ * NOT silently fall through to whatever else happens to be configured. Only
+ * 'auto' walks the priority list and falls back.
+ *
+ * Exercises the REAL config store (isolated to a temp dir by the vitest setup)
+ * and the REAL selectProvider — no mocks — so it proves end-to-end wiring.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { selectProvider, ProviderUnavailableError } from '../src/providers/index.js';
+import { resetConfig, setProviderCred } from '../src/config.js';
+
+// Provider credential env vars can leak in from the developer's shell and make a
+// provider look configured. Clear them so the store is the only source of truth.
+const PROVIDER_ENV_VARS = [
+  'ANTHROPIC_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_API_KEY', 'OLLAMA_BASE_URL',
+  'LITELLM_BASE_URL', 'LITELLM_API_KEY', 'TOGETHER_API_KEY', 'OPENROUTER_API_KEY',
+  'GROQ_API_KEY', 'FIREWORKS_API_KEY', 'MISTRAL_API_KEY', 'AI21_API_KEY',
+  'HUGGINGFACE_API_KEY', 'BEDROCK_API_KEY', 'BEDROCK_BASE_URL',
+  'AWS_REGION', 'AWS_DEFAULT_REGION', 'AWS_PROFILE', 'AWS_ACCESS_KEY_ID',
+  'OPENAI_COMPAT_BASE_URL', 'OPENAI_COMPAT_API_KEY',
+];
+
+const clearEnv = () => { for (const n of PROVIDER_ENV_VARS) delete process.env[n]; };
+
+beforeEach(() => { resetConfig(); clearEnv(); });
+afterEach(() => { resetConfig(); clearEnv(); });
+
+describe('selectProvider — explicit provider without credentials (#217)', () => {
+  it('throws ProviderUnavailableError with the fix hint for an API-key provider', () => {
+    let caught: unknown;
+    try { selectProvider('openai'); } catch (e) { caught = e; }
+
+    expect(caught).toBeInstanceOf(ProviderUnavailableError);
+    expect((caught as ProviderUnavailableError).provider).toBe('openai');
+    const msg = (caught as Error).message;
+    expect(msg).toContain('openai is selected but has no API key');
+    expect(msg).toContain('calliope --setup');
+    expect(msg).toContain('/config set providers.openai.apiKey');
+    expect(msg).toContain('OPENAI_API_KEY');
+  });
+
+  it('does NOT silently fall through to a different configured provider', () => {
+    // anthropic IS configured; selecting openai must still fail, not switch.
+    setProviderCred('anthropic', { apiKey: 'sk-ant-configured' });
+    expect(() => selectProvider('openai')).toThrow(ProviderUnavailableError);
+  });
+
+  it('gives an AWS-credentials hint for bedrock', () => {
+    let caught: unknown;
+    try { selectProvider('bedrock'); } catch (e) { caught = e; }
+
+    expect(caught).toBeInstanceOf(ProviderUnavailableError);
+    const msg = (caught as Error).message;
+    expect(msg).toContain('bedrock is selected but has no AWS credentials');
+    expect(msg).toContain('AWS_PROFILE or AWS_ACCESS_KEY_ID');
+  });
+
+  it('returns the provider when its credential is present (store)', () => {
+    setProviderCred('openai', { apiKey: 'sk-openai-live' });
+    expect(selectProvider('openai')).toBe('openai');
+  });
+
+  it('returns the provider when its credential is present (env var)', () => {
+    process.env.MISTRAL_API_KEY = 'mistral-env-key';
+    expect(selectProvider('mistral')).toBe('mistral');
+  });
+
+  it('honors bedrock when AWS_PROFILE is set', () => {
+    process.env.AWS_PROFILE = 'dev';
+    expect(selectProvider('bedrock')).toBe('bedrock');
+  });
+});
+
+describe('selectProvider — auto still falls back (#217)', () => {
+  it("'auto' returns the highest-priority configured cloud provider", () => {
+    setProviderCred('google', { apiKey: 'g-key' });
+    // Priority is anthropic > openai > google > …; only google is configured.
+    expect(selectProvider('auto')).toBe('google');
+  });
+
+  it("'auto' prefers anthropic over a lower-priority configured provider", () => {
+    setProviderCred('anthropic', { apiKey: 'sk-ant' });
+    setProviderCred('google', { apiKey: 'g-key' });
+    expect(selectProvider('auto')).toBe('anthropic');
+  });
+
+  it("'auto' with no cloud keys resolves to the local ollama default, never throws", () => {
+    // ollama always has a default base URL (localhost:11434), so 'auto' lands
+    // there rather than failing — the local-first fallback.
+    expect(selectProvider('auto')).toBe('ollama');
+  });
+});

--- a/tests/setup/isolate-stores.ts
+++ b/tests/setup/isolate-stores.ts
@@ -44,3 +44,10 @@ if (!process.env.CALLIOPE_CONFIG_DIR) {
   process.env.HOME = base;
   process.env.USERPROFILE = base; // Windows CI
 }
+
+// Hermeticity: never let the AWS SDK's credential chain reach for the EC2
+// metadata endpoint (on CI runners the IMDS attempt retries past test
+// timeouts — the cause of the #214 bedrock hang). Tests that need
+// credentials set their own env explicitly.
+process.env.AWS_EC2_METADATA_DISABLED = 'true';
+process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = '';

--- a/tests/setup/isolate-stores.ts
+++ b/tests/setup/isolate-stores.ts
@@ -1,0 +1,46 @@
+/**
+ * Test store isolation (#217).
+ *
+ * Every on-disk store the CLI touches — the conf config store, and every
+ * `~/.calliope-cli/*` / `~/.config/calliope/*` writer (runlog, budget, skills,
+ * themes, storage, memory, hooks, mcp, plugins, trust, version cache) — must be
+ * redirected to a throwaway directory so the suite can never read or clobber the
+ * developer's real config. (The config test suite calls `resetConfig()`, which
+ * is `conf.clear()`; under the real path that wiped the developer's store.)
+ *
+ * Vitest runs setupFiles before each test file, but `process.env` persists for
+ * the life of a worker, so the `if (!already-set)` guard makes this effectively
+ * per-worker: the first file in a worker mints one base dir; later files in the
+ * same worker reuse it. Distinct workers get distinct dirs (unique mkdtemp +
+ * VITEST_POOL_ID), which also removes the cross-worker store races behind the
+ * flaky bedrock (#214) and skills (#206) suites.
+ *
+ * Two levers:
+ *   - CALLIOPE_CONFIG_DIR → conf's `cwd` (src/config.ts honors it).
+ *   - HOME / USERPROFILE  → os.homedir(), which every state dir derives from.
+ *     env-paths (used by conf) also follows HOME, so this is belt-and-suspenders
+ *     on top of CALLIOPE_CONFIG_DIR.
+ *
+ * Tests that `vi.mock('os')` to their own tmp home still win for their own
+ * module graph — this only redirects the unmocked default.
+ */
+import { mkdtempSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+if (!process.env.CALLIOPE_CONFIG_DIR) {
+  const tag = process.env.VITEST_POOL_ID ?? String(process.pid);
+  // realpath the base so $HOME is already canonical (macOS os.tmpdir() lives
+  // under the symlinked /var/folders → /private/var/folders). Code that
+  // realpath-resolves a target path and compares it against os.homedir()
+  // (e.g. src/scope.ts) then still matches.
+  const base = realpathSync(mkdtempSync(join(tmpdir(), `calliope-test-${tag}-`)));
+
+  // conf store → <base>/config.json (base already exists from mkdtemp).
+  process.env.CALLIOPE_CONFIG_DIR = base;
+
+  // Redirect the home directory so os.homedir()-derived state dirs
+  // (~/.calliope-cli/*, ~/.config/calliope/*) land under the throwaway base.
+  process.env.HOME = base;
+  process.env.USERPROFILE = base; // Windows CI
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    // Redirect every on-disk store (conf config + ~/.calliope-cli/*) to a
+    // per-worker throwaway dir so the suite can never touch the real store (#217).
+    setupFiles: ['tests/setup/isolate-stores.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'json-summary'],


### PR DESCRIPTION
## Summary
Live testing surfaced 'the agent is not agenting': the UI claimed openai:gpt-4o while local gemma4:31b silently served every turn. Three stacked causes, all fixed:
1. Data loss: tests mutated the REAL conf store (resetConfig in beforeEach wiped user credentials). Now: CALLIOPE_CONFIG_DIR honored, hard guard refuses to construct under VITEST without isolation, per-worker temp HOME makes the suite hermetic. Real store proven byte-identical across suite+bench+guard runs
2. Silent provider switch: explicit provider without credentials now throws ProviderUnavailableError with per-provider fix hints (env var, /config set, --setup); auto keeps priority fallback; TUI survives and shows the fix; headless exits 2; banner annotates unconfigured providers
3. Silent model substitution: ollama fallback populates LLMResponse.warnings, surfaced in TUI (deduped per session) and headless
Bonus: fixed a latent headless double-selectProvider crash path; bedrock/skills/themes flake families stable 3x under isolation (#206/#214)

## Test Plan
- npm test: 3,714 passed, 4 skipped (109 files) — fully hermetic now
- npm run bench PASS; guard demo: VITEST without isolation dir refuses at import, store untouched (shasum-verified)

Fixes #217