### PR TITLE
Load cli.env from a global config location

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,3 +163,14 @@ calliope --reset      # clear all configuration
 ```
 
 See [Getting started](./getting-started.md) for the full flag list.
+
+### Env file locations
+
+`calliope` loads dotenv-style files at startup, never overwriting values
+that are already set. Priority order:
+
+1. Real environment variables
+2. `.env` in the current directory
+3. `cli.env` in the current directory
+4. `~/.config/calliope/cli.env` (global — credentials that should work
+   from any directory)

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { runSetup } from './setup.js';
 import * as config from './config.js';
 import { getVersion, checkForUpdates, getLatestVersion, performUpgrade } from './version-check.js';
+import * as os from 'os';
 import { colors } from './styles.js';
 
 // Load .env / cli.env files (dotenv-style, no dependency)
@@ -41,9 +42,12 @@ function loadEnvFile(filePath: string): void {
   }
 }
 
-// Check for env files in cwd and home directory (cwd takes priority)
+// Env file load order (loadEnvFile never overwrites, so earlier = higher
+// priority): real environment > cwd .env > cwd cli.env > global cli.env.
+// The global file lets credentials work from any directory (#219).
 loadEnvFile(path.join(process.cwd(), '.env'));
 loadEnvFile(path.join(process.cwd(), 'cli.env'));
+loadEnvFile(path.join(os.homedir(), '.config', 'calliope', 'cli.env'));
 
 // Suppress OpenAI/third-party SDK verbose debug output triggered by DEBUG=true
 // (JupyterHub sets DEBUG=true in the container environment which causes OpenAI SDK
@@ -349,6 +353,10 @@ ${bold('ENVIRONMENT VARIABLES')}
   BEDROCK_API_KEY       AWS Bedrock gateway API key (if required)
   OPENAI_COMPAT_BASE_URL   Generic OpenAI-compatible server URL (e.g. http://localhost:1234/v1)
   OPENAI_COMPAT_API_KEY    API key for the OpenAI-compatible server (if required)
+
+  Variables load from, in priority order: the environment itself, then
+  .env and cli.env in the current directory, then ~/.config/calliope/cli.env
+  (global). Existing values are never overwritten.
 
   CALLIOPE_MAX_RETRIES  Override --max-retries default (headless mode)
 

--- a/tests/env-files.test.ts
+++ b/tests/env-files.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// The loader in bin.ts is module-scoped; replicate its contract here by
+// importing bin with a controlled cwd/HOME. bin.ts runs main() at load, so
+// we exercise the parsing/precedence contract through a focused re-import
+// with CALLIOPE_NO_AUTORUN (same pattern as signals.test.ts).
+
+let tmpBase: string;
+let cwdDir: string;
+let homeDir: string;
+const TEST_KEYS = ['CALLIOPE_T219_A', 'CALLIOPE_T219_B', 'CALLIOPE_T219_C', 'CALLIOPE_T219_M'] as const;
+
+beforeEach(() => {
+  tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-envfiles-'));
+  cwdDir = path.join(tmpBase, 'proj');
+  homeDir = path.join(tmpBase, 'home');
+  fs.mkdirSync(path.join(homeDir, '.config', 'calliope'), { recursive: true });
+  fs.mkdirSync(cwdDir, { recursive: true });
+  for (const k of TEST_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of TEST_KEYS) delete process.env[k];
+  fs.rmSync(tmpBase, { recursive: true, force: true });
+});
+
+async function loadBinWith(env: Record<string, string | undefined>): Promise<void> {
+  const { vi } = await import('vitest');
+  vi.resetModules();
+  const prevCwd = process.cwd();
+  const prevHome = process.env.HOME;
+  process.env.CALLIOPE_NO_AUTORUN = '1';
+  try {
+    process.chdir(cwdDir);
+    process.env.HOME = homeDir;
+    Object.assign(process.env, env);
+    await import('../src/bin.js');
+  } finally {
+    process.chdir(prevCwd);
+    process.env.HOME = prevHome;
+    delete process.env.CALLIOPE_NO_AUTORUN;
+  }
+}
+
+describe('env file loading precedence (#219)', () => {
+  it('loads the global ~/.config/calliope/cli.env', async () => {
+    fs.writeFileSync(path.join(homeDir, '.config', 'calliope', 'cli.env'), 'CALLIOPE_T219_A=global\n');
+    await loadBinWith({});
+    expect(process.env.CALLIOPE_T219_A).toBe('global');
+  });
+
+  it('cwd files beat the global file; env beats everything', async () => {
+    fs.writeFileSync(path.join(homeDir, '.config', 'calliope', 'cli.env'), 'CALLIOPE_T219_A=global\nCALLIOPE_T219_B=global\nCALLIOPE_T219_C=global\n');
+    fs.writeFileSync(path.join(cwdDir, 'cli.env'), 'CALLIOPE_T219_B=cwd\nCALLIOPE_T219_C=cwd\n');
+    await loadBinWith({ CALLIOPE_T219_C: 'realenv' });
+    expect(process.env.CALLIOPE_T219_A).toBe('global');   // only global defines it
+    expect(process.env.CALLIOPE_T219_B).toBe('cwd');      // cwd wins over global
+    expect(process.env.CALLIOPE_T219_C).toBe('realenv');  // env wins over both
+  });
+
+  it('missing files are silent no-ops and malformed lines are skipped', async () => {
+    fs.writeFileSync(path.join(homeDir, '.config', 'calliope', 'cli.env'), '# comment\nnot a valid line\nCALLIOPE_T219_M=ok\n');
+    await loadBinWith({});
+    expect(process.env.CALLIOPE_T219_M).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary
- ~/.config/calliope/cli.env joins the load order below the cwd files: environment > cwd .env > cwd cli.env > global (loadEnvFile never overwrites, so later = lower priority)
- Help env-var section + docs/configuration.md document the precedence
- 3 precedence tests with isolated cwd/HOME (never touch the real home)

## Test Plan
- npm test: 3,719 passed, 4 skipped (110 files); new tests/env-files.test.ts covers global load, cwd-beats-global, env-beats-all, malformed-line tolerance

Fixes #219