### PR TITLE
Require evidence-based plans; mark unverified plans

### DIFF
--- a/src/ui/agent.ts
+++ b/src/ui/agent.ts
@@ -503,6 +503,23 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
         ctx.llmMessages.current = validatedMessages;
       }
 
+      // Plan mode: tell the model it is planning and that plans need receipts.
+      // Injected per-request (not persisted) so mode switches take effect
+      // immediately and history stays clean.
+      if (ctx.mode === 'plan') {
+        validatedMessages = [
+          ...validatedMessages,
+          {
+            role: 'system' as const,
+            content: 'You are in PLAN mode: no mutating tools will execute. '
+              + 'Read-only tools (read_file, list_files, think, create_plan, ask_question) ARE available — use them. '
+              + 'Before proposing any plan, read the files you intend to change and cite file:line for every claim. '
+              + 'State explicitly what you verified versus what you assume. '
+              + 'A plan produced without reading anything will be marked unverified.',
+          },
+        ];
+      }
+
       // Pre-request summarization check - summarize BEFORE sending if context is too large
       const tools = getTools();
       const contextCheck = estimateContextUsage(ctx.provider, effectiveModel || DEFAULT_MODELS[ctx.provider], validatedMessages, tools);
@@ -1115,6 +1132,11 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
 
   // Process any queued messages (human-in-the-loop feedback)
   // CRITICAL: Use ref to get current value, not stale closure
+  // #224: a plan produced with zero tool calls carries no evidence — say so.
+  if (ctx.mode === 'plan' && runToolCalls === 0) {
+    ctx.addMessage('system', '⚠ Unverified plan — the agent read nothing to produce this. Ask it to verify (it can read files in plan mode), or treat claims as assumptions.');
+  }
+
   const currentQueued = ctx.queuedMessagesRef.current;
   ctx.debugLog('runAgent', 'EXIT loop', `queued=${currentQueued.length}`);
   if (currentQueued.length > 0) {

--- a/tests/plan-mode-evidence.test.ts
+++ b/tests/plan-mode-evidence.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentContext } from '../src/ui/agent.js';
+import type { Message as LLMMessage, LLMProvider, Mode } from '../src/types.js';
+
+const chatMock = vi.fn();
+const saveMessageHistoryMock = vi.fn();
+
+vi.mock('../src/config.js', () => ({
+  default: {},
+  get: vi.fn((key: string) => {
+    if (key === 'maxIterations') return 1;
+    if (key === 'audit') return { enabled: false }; // no run-log disk writes in tests
+    return undefined;
+  }),
+  getConfig: vi.fn(() => ({})),
+}));
+
+vi.mock('../src/providers/index.js', () => ({
+  chat: (...args: unknown[]) => chatMock(...args),
+  getAvailableProviders: vi.fn(() => ['openai', 'google']),
+}));
+
+vi.mock('../src/providers/types.js', () => ({
+  estimateContextUsage: vi.fn(() => ({
+    estimated: 100,
+    limit: 100000,
+    percent: 1,
+    needsSummarization: false,
+  })),
+  needsSummarization: vi.fn(() => false),
+}));
+
+vi.mock('../src/tools.js', () => ({
+  executeTool: vi.fn(),
+  getTools: vi.fn(() => []),
+}));
+
+vi.mock('../src/types.js', () => ({
+  DEFAULT_MODELS: { openai: 'gpt-4o' },
+  RISK_CONFIG: {},
+  calculateCost: vi.fn(() => 0),
+}));
+
+vi.mock('../src/model-detection.js', () => ({
+  getModelContextLimit: vi.fn(() => 100000),
+  getModelMaxOutput: vi.fn(() => 8192),
+}));
+
+vi.mock('../src/risk.js', () => ({
+  assessToolRisk: vi.fn(() => ({ level: 'low', reason: '', canAutoApprove: true })),
+  requiresConfirmation: vi.fn(() => false),
+}));
+
+vi.mock('../src/errors.js', () => ({
+  formatError: vi.fn((error: unknown) => error instanceof Error ? error.message : String(error)),
+  classifyError: vi.fn(() => ({ category: 'other' })),
+}));
+
+vi.mock('../src/storage.js', () => ({
+  saveMessageHistory: (...args: unknown[]) => saveMessageHistoryMock(...args),
+  recordCost: vi.fn(),
+}));
+
+vi.mock('../src/hooks.js', () => ({
+  checkHooksAllow: vi.fn(async () => ({ allowed: true })),
+  executeHooks: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../src/router.js', () => ({
+  routeRequest: vi.fn(),
+  smartRoute: vi.fn(),
+  getDefaultSmartRoutingConfig: vi.fn(() => ({ enabled: false })),
+}));
+
+vi.mock('../src/summarization.js', () => ({
+  validateMessageHistory: vi.fn((messages: unknown[]) => messages),
+  summarizeConversation: vi.fn((messages: unknown[]) => ({
+    messages,
+    summarizedCount: 0,
+    originalTokens: 0,
+    reducedTokens: 0,
+    summary: '',
+  })),
+  estimateTotalTokens: vi.fn(() => 100),
+  summarizeMessages: vi.fn(() => ''),
+}));
+
+vi.mock('../src/parallel-tools.js', () => ({
+  executeParallel: vi.fn(),
+  getParallelizationStats: vi.fn(() => ({
+    totalCalls: 0,
+    parallelCalls: 0,
+    sequentialCalls: 0,
+    stages: 0,
+  })),
+}));
+
+
+vi.mock('../src/ui/context.js', () => ({
+  checkAndWarnContextLimit: vi.fn(),
+}));
+
+vi.mock('../src/circuit-breaker.js', () => ({
+  CircuitBreaker: vi.fn(),
+}));
+
+vi.mock('../src/iteration-ledger.js', () => ({
+  IterationLedger: vi.fn(),
+}));
+
+vi.mock('../src/checkpoint.js', () => ({
+  shouldCheckpoint: vi.fn(() => false),
+  createCheckpoint: vi.fn(),
+}));
+
+
+vi.mock('../src/prevent-sleep.js', () => ({
+  startPreventSleep: vi.fn(),
+  stopPreventSleep: vi.fn(),
+}));
+
+const { runAgentImpl } = await import('../src/ui/agent.js');
+
+function makeCtx(): AgentContext & { collectedMessages: Array<{ type: string; content: string }> } {
+  const collectedMessages: Array<{ type: string; content: string }> = [];
+  const llmMessages: LLMMessage[] = [];
+
+  const ctx = {
+    provider: 'openai' as LLMProvider,
+    model: 'gpt-4o',
+    mode: 'hybrid' as Mode,
+    confirmMode: false,
+    autoRoute: false,
+    actualProvider: 'openai',
+    actualModel: 'gpt-4o',
+    stats: {
+      messageCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+    },
+
+    setStats: vi.fn((value: unknown) => {
+      if (typeof value === 'function') {
+        ctx.stats = value(ctx.stats);
+      } else {
+        ctx.stats = value as AgentContext['stats'];
+      }
+    }),
+    setStreamingResponse: vi.fn(),
+    setThinkingState: vi.fn(),
+    setActivityState: vi.fn(),
+    setContextTokens: vi.fn(),
+    setIsProcessing: vi.fn(),
+    setQueuedMessages: vi.fn(),
+    setEditingQueueIndex: vi.fn(),
+    setLoopIteration: vi.fn(),
+    setLoopActive: vi.fn(),
+
+    llmMessages: { current: llmMessages },
+    queuedMessagesRef: { current: [] as string[] },
+    loopCancelledRef: { current: false },
+    sessionRef: { current: null },
+
+    addMessage: (type: 'user' | 'assistant' | 'tool' | 'system' | 'error', content: string) => {
+      collectedMessages.push({ type, content });
+    },
+    estimateContextTokens: vi.fn(() => 0),
+    validateAndRepairMessages: vi.fn(() => true),
+
+    debugLog: vi.fn(),
+    collectedMessages,
+  } as unknown as AgentContext & { collectedMessages: Array<{ type: string; content: string }> };
+
+  return ctx;
+}
+
+
+describe('plan mode evidence (#224)', () => {
+  beforeEach(() => {
+    chatMock.mockReset();
+    saveMessageHistoryMock.mockReset();
+  });
+
+  it('injects the plan-mode instruction into outgoing messages (plan only)', async () => {
+    chatMock.mockResolvedValue({ content: 'Here is my plan.', toolCalls: [] });
+
+    const planCtx = makeCtx();
+    (planCtx as { mode: string }).mode = 'plan';
+    await runAgentImpl(planCtx, 'plan something');
+    const planMessages = chatMock.mock.calls[0][1] as Array<{ role: string; content: string }>;
+    expect(planMessages.some(m => m.role === 'system' && m.content.includes('PLAN mode'))).toBe(true);
+    // The transient instruction must not persist into history
+    expect(planCtx.llmMessages.current.some(m => typeof m.content === 'string' && m.content.includes('PLAN mode'))).toBe(false);
+
+    chatMock.mockClear();
+    chatMock.mockResolvedValue({ content: 'Done.', toolCalls: [] });
+    const hybridCtx = makeCtx();
+    await runAgentImpl(hybridCtx, 'do something');
+    const hybridMessages = chatMock.mock.calls[0][1] as Array<{ role: string; content: string }>;
+    expect(hybridMessages.some(m => m.role === 'system' && m.content.includes('PLAN mode'))).toBe(false);
+  });
+
+  it('marks a zero-tool-call plan as unverified', async () => {
+    chatMock.mockResolvedValue({ content: 'A confident plan with no receipts.', toolCalls: [] });
+    const ctx = makeCtx();
+    (ctx as { mode: string }).mode = 'plan';
+    await runAgentImpl(ctx, 'plan the refactor');
+    const marker = ctx.collectedMessages.find(m => m.type === 'system' && m.content.includes('Unverified plan'));
+    expect(marker).toBeDefined();
+  });
+
+  it('does not mark a plan that read files', async () => {
+    const { executeTool } = await import('../src/tools.js');
+    (executeTool as ReturnType<typeof vi.fn>).mockResolvedValue({ toolCallId: 't1', result: 'file contents', isError: false });
+    chatMock
+      .mockResolvedValueOnce({ content: '', toolCalls: [{ id: 't1', name: 'read_file', arguments: { path: 'src/bin.ts' } }], finishReason: 'tool_use' })
+      .mockResolvedValueOnce({ content: 'Plan citing bin.ts:45.', toolCalls: [] });
+    const ctx = makeCtx();
+    (ctx as { mode: string }).mode = 'plan';
+    await runAgentImpl(ctx, 'plan the refactor');
+    const marker = ctx.collectedMessages.find(m => m.type === 'system' && m.content.includes('Unverified plan'));
+    expect(marker).toBeUndefined();
+  });
+
+  it('never marks outside plan mode', async () => {
+    chatMock.mockResolvedValue({ content: 'Just an answer.', toolCalls: [] });
+    const ctx = makeCtx();
+    await runAgentImpl(ctx, 'hi');
+    expect(ctx.collectedMessages.some(m => m.content.includes('Unverified plan'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Live-test finding: plan mode never told the model it was in plan mode — enforcement was purely mechanical tool-blocking, so models returned polished prompt-echoes with zero tool calls (audit-verified). Now:
- Plan mode injects a transient system instruction each turn: read-only tools are available, read before proposing, cite file:line, separate verified from assumed
- A plan-mode turn that ends with zero tool calls gets a visible transcript marker: unverified plan, treat claims as assumptions
- Instruction never persists into message history; mode switches take effect immediately

## Test Plan
- 4 new tests (instruction injected in plan mode only + not persisted; marker on zero-tool plans; no marker when files were read; never outside plan mode)
- npm test: full suite green

Fixes #224