### PR TITLE
Add integrity gate for installed skills and plugins

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ provider backends, and a small, tested command surface.
 - [Local models](./local-models.md) — how the harness adapts to self-hosted 7-70B models
 - [Features](./features.md) — the full v3 feature set (and what was removed)
 - [Governance](./governance.md) — audit run logs, replay, budget caps, policy hook
+- [Security](./security.md) — skill & plugin trust (trust-on-first-use integrity gate)
 - [Editors (ACP)](./acp.md) — run Calliope as an Agent Client Protocol agent in Zed, JetBrains, and more
 - [Fleet mode](./fleet.md) — optional multi-agent coordination over IRC
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,6 +86,12 @@ are stored under `~/.calliope-cli/`.
 /skills add https://github.com/org/skill
 ```
 
+Installed skills and plugins are pinned by content hash and re-verified on every
+load — a trust-on-first-use integrity gate that refuses to run an artifact whose
+content changed since you accepted it. `/skills` shows each entry's fingerprint
+or a `CHANGED` / `UNVERIFIED` marker. See [security](./security.md) for the trust
+model and its limits.
+
 ## Hooks (file-driven)
 
 Run shell commands on lifecycle events — `pre-tool` / `post-tool`,

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,119 @@
+# Security: skill & plugin trust (TOFU)
+
+Skills and plugins are code and instructions that Calliope runs **in-process**:
+
+- a **plugin**'s `index.js` is `import()`-ed, so its code executes with the full
+  privileges of the CLI;
+- a **skill**'s `SKILL.md` is fed into the model's system prompt, so its text can
+  steer the agent (prompt injection).
+
+Both can be fetched from the network (the agentskills.io registry, a GitHub URL)
+or dropped into `~/.calliope-cli/`. To stop *silent* tampering after you have
+accepted an artifact, Calliope pins a content hash at install time and
+re-verifies it on every load. This is a **trust-on-first-use (TOFU)** model — the
+same shape as SSH host keys.
+
+## What is pinned, and where
+
+| Artifact | Hashed content | Pin store |
+|----------|----------------|-----------|
+| Skill    | `SKILL.md` (sha256) | `~/.calliope-cli/skills/index.json` → entry `hash` |
+| Plugin   | `index.js` (sha256) | `~/.calliope-cli/plugins/trust.json` → entry `hash` |
+
+A short **fingerprint** — `sha256:` plus the first 12 hex characters of the
+digest — is shown wherever trust is surfaced, so you can eyeball it.
+
+## The lifecycle
+
+1. **First install / first load (trust-on-first-use).** The artifact is fetched,
+   its hash recorded, and the fingerprint printed:
+
+   ```
+   ✓ Installed git-workflow — pinned sha256:1a2b3c4d5e6f (trust-on-first-use)
+   Plugin toolbox: trusted on first use — entry-file fingerprint sha256:9f8e7d6c5b4a
+   ```
+
+   Network installs also pass through a confirmation gate before anything is
+   written to disk.
+
+2. **Every subsequent load — verify.** Before a skill enters the prompt or a
+   plugin's code is imported, its on-disk content is re-hashed and compared to
+   the pin. **Match → load. Mismatch → refuse**, with a clear message telling you
+   to reinstall to re-trust. A tampered skill is withheld from the model; a
+   changed plugin is never imported.
+
+3. **Audit.** When audit run logs are on (the default — see
+   [governance](./governance.md)), a refused load is recorded as a `policy_event`
+   with `source: "integrity"` in a dedicated `security` trace, so the tamper is
+   not lost to a console warning that scrolls away.
+
+4. **Update — explicit re-pin, never silent.** Reinstalling an artifact whose
+   content changed is treated as an update: the confirmation shows the
+   `content-changed` reason, and the surface prints the fingerprint diff:
+
+   ```
+   ✓ Re-pinned git-workflow: sha256:1a2b3c4d5e6f → sha256:0099aabbccdd (content updated)
+   ```
+
+   The pin is only replaced through this visible path.
+
+## Trust state in listings
+
+`/skills` and the plugin list annotate every entry with its trust state:
+
+- the pinned **fingerprint** (`sha256:…`) when the content still matches;
+- **`CHANGED`** when the content drifted from its pin (withheld / refused);
+- **`UNVERIFIED`** when no hash was recorded (a legacy entry installed before
+  pinning);
+- **`dev, unverified`** for an exempted local dev plugin (below).
+
+A `CHANGED` plugin refuses to load, so it would otherwise vanish from the list;
+it is listed explicitly so the state is never silently hidden.
+
+## Local dev plugins (exemption)
+
+A plugin you are actively editing would re-prompt on every save. You can exempt
+it from pinning — but **only as a user-side decision**; a plugin can never mark
+itself exempt through its own manifest. Two levers:
+
+- **Env flag** — `CALLIOPE_PLUGIN_DEV=1` exempts *all* plugins for that process
+  (blanket dev mode);
+- **Config allowlist** — name specific plugins in `plugins.devTrustLocal`:
+
+  ```jsonc
+  // ~/.calliope config
+  { "plugins": { "devTrustLocal": ["my-wip-plugin"] } }
+  ```
+
+Exempted plugins load without pinning and are shown as `dev, unverified`. Skills
+installed from a local path are **copied** into the store and pinned like any
+other — the exemption is a plugin-only concern, for live-edited code.
+
+## What TOFU does and does not defend
+
+TOFU defends the window **after** you accept an artifact: it catches later
+tampering (a compromised update, a local edit, accidental drift) and refuses to
+run it.
+
+It explicitly does **not** defend the **first** install. If the registry or the
+GitHub source is already compromised the very first time you fetch, TOFU will
+faithfully pin and trust the malicious content — there is no prior good hash to
+compare against. Closing that gap requires **artifact signing** (verifying a
+publisher signature against a trusted key), tracked in
+[issue #223](https://github.com/calliopeai/calliope-cli/issues/223).
+
+Other limits worth stating plainly:
+
+- **Scope of the hash.** Only `SKILL.md` (skills) and `index.js` (plugins) are
+  hashed. A plugin that `require()`s sibling files, or a skill's `scripts/` and
+  `assets/`, are not covered by the pin. Prefer single-file plugins; treat a
+  skill's scripts as you would any downloaded script.
+- **Transport.** Fetches are plain HTTPS; you are trusting TLS and the registry,
+  not a signature.
+- **Local attacker.** The pin store lives in the same `~/.calliope-cli/` tree it
+  protects. An attacker who already has write access to your home directory can
+  rewrite both the artifact and its pin. TOFU raises the bar against remote and
+  accidental tampering, not against an adversary who already owns your account.
+
+See also: [governance](./governance.md) for the audit run-log format and
+`calliope replay`, and the root [`SECURITY.md`](../SECURITY.md) for reporting.

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,12 @@ export interface CalliopeConfig {
     command?: string;
     timeoutMs?: number;  // default 5000
   };
+  // Plugin trust (#137). `devTrustLocal` names locally-edited plugins that are
+  // exempt from entry-file hash pinning (see docs/security.md). A plugin cannot
+  // add itself here — exemption is always a user-side decision.
+  plugins?: {
+    devTrustLocal?: string[];
+  };
 }
 
 const DEFAULT_CONFIG: CalliopeConfig = {
@@ -150,6 +156,7 @@ const config = new Conf<CalliopeConfig>({
     audit: { type: 'object' },
     budget: { type: 'object' },
     policy: { type: 'object' },
+    plugins: { type: 'object' },
   },
 });
 
@@ -416,6 +423,8 @@ const SURVIVOR_KEYS = new Set<string>([
   'sandboxMode', 'routing', 'sessionLogLimit',
   // Governance (#189)
   'audit', 'budget', 'policy',
+  // Plugin trust (#137)
+  'plugins',
 ]);
 
 /**

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -10,6 +10,19 @@ import * as path from 'path';
 import * as os from 'os';
 import * as crypto from 'crypto';
 import type { Tool, ToolCall, ToolResult } from './types.js';
+import * as config from './config.js';
+import { auditIntegrityViolation } from './runlog.js';
+
+/** Short, human-comparable fingerprint of a full sha256 hex digest (#137). */
+function fingerprint(hash: string): string {
+  return `sha256:${hash.slice(0, 12)}`;
+}
+
+/** Blanket local-dev mode via env: exempts every plugin from hash pinning (#137). */
+function isPluginDevEnvEnabled(): boolean {
+  const v = process.env.CALLIOPE_PLUGIN_DEV;
+  return v === '1' || v === 'true' || v === 'yes';
+}
 
 // ============================================================================
 // Types
@@ -69,6 +82,15 @@ export interface PluginTrustConfirmation {
   reason: 'first-load' | 'entry-file-changed';
 }
 
+/**
+ * Trust state of an installed plugin's entry file relative to its pinned hash (#137).
+ *  - `pinned`     — index.js matches the recorded hash.
+ *  - `changed`    — hash recorded but index.js no longer matches (refused at load).
+ *  - `unverified` — no hash recorded yet.
+ *  - `dev`        — user-exempted local dev plugin (not pinned by design).
+ */
+export type PluginTrust = 'pinned' | 'changed' | 'unverified' | 'dev';
+
 // ============================================================================
 // Plugin Manager
 // ============================================================================
@@ -125,16 +147,41 @@ class PluginManager {
   }
 
   /**
+   * Whether a plugin is a user-trusted local dev plugin, exempt from entry-file
+   * hash pinning (#137). Exemption is ALWAYS a user-side decision — the blanket
+   * `CALLIOPE_PLUGIN_DEV` env flag or a `plugins.devTrustLocal` config allowlist.
+   * A plugin can never mark itself exempt through its own manifest.
+   */
+  private isDevTrustExempt(name: string): boolean {
+    if (isPluginDevEnvEnabled()) return true;
+    try {
+      const cfg = config.get('plugins') as { devTrustLocal?: string[] } | undefined;
+      return Array.isArray(cfg?.devTrustLocal) && cfg.devTrustLocal.includes(name);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Gate a plugin load behind trust-on-first-use + hash re-verification (#137).
    * Returns true if the plugin may be imported/executed.
    *
+   * - Dev-exempt (user opt-in): load without pinning.
    * - First time seen: record the hash. If a trust handler is set, ask it;
    *   with no handler, trust-on-first-use (backward compatible).
    * - Seen before, hash matches: allow silently.
    * - Seen before, hash changed: require confirmation. With no handler, refuse
-   *   (do not silently run changed code).
+   *   (do not silently run changed code) and audit the refusal.
    */
   private async checkPluginTrust(name: string, indexPath: string, manifest: PluginMetadata): Promise<boolean> {
+    // Locally-edited dev plugins the user explicitly trusts are exempt from
+    // pinning, so an actively-changing entry file is not re-confirmed on every
+    // edit. Never silent: still announce that the plugin is unverified (#137).
+    if (this.isDevTrustExempt(name)) {
+      console.log(`Plugin ${name}: loaded as trusted-local dev plugin (unverified — hash not pinned)`);
+      return true;
+    }
+
     const store = this.loadTrustStore();
     const currentHash = this.hashFile(indexPath);
     const known = store[name];
@@ -158,14 +205,74 @@ class PluginManager {
         return false;
       }
     } else if (known) {
-      // Entry file changed and we cannot prompt — refuse rather than run silently.
+      // Entry file changed and we cannot prompt — refuse rather than run silently,
+      // and record the tamper in the audit trail (#137).
       console.warn(`Plugin ${name}: index.js changed since last load — refusing to load (re-trust required)`);
+      auditIntegrityViolation(
+        `plugin:${name}`,
+        'index.js changed since last trusted load — refusing to load (re-trust required)',
+      );
       return false;
     }
 
+    // Pin (or re-pin) the entry file. Surface the fingerprint so both
+    // trust-on-first-use and an approved re-trust are visible, never silent.
+    if (known) {
+      console.log(
+        `Plugin ${name}: re-trusted — entry-file fingerprint ${fingerprint(known.hash)} → ${fingerprint(currentHash)}`,
+      );
+    } else {
+      console.log(`Plugin ${name}: trusted on first use — entry-file fingerprint ${fingerprint(currentHash)}`);
+    }
     store[name] = { hash: currentHash };
     this.saveTrustStore(store);
     return true;
+  }
+
+  /**
+   * Trust state of a plugin's entry file relative to its pinned hash (#137), for
+   * the listing surface. Reads disk only — never imports plugin code.
+   */
+  getPluginTrustState(name: string): { trust: PluginTrust; fingerprint?: string } {
+    if (this.isDevTrustExempt(name)) return { trust: 'dev' };
+    const known = this.loadTrustStore()[name];
+    if (!known) return { trust: 'unverified' };
+    let current: string | undefined;
+    try {
+      current = this.hashFile(path.join(this.pluginsDir, name, 'index.js'));
+    } catch {
+      current = undefined;
+    }
+    return current === known.hash
+      ? { trust: 'pinned', fingerprint: fingerprint(known.hash) }
+      : { trust: 'changed', fingerprint: fingerprint(known.hash) };
+  }
+
+  /**
+   * Names of plugins present on disk whose pinned hash no longer matches their
+   * entry file and that are not currently loaded — i.e. refused at load time
+   * because the code changed. Surfaced in the listing so a "vanished" plugin is
+   * explained rather than silently missing (#137).
+   */
+  private getChangedPluginDirs(): string[] {
+    if (!fs.existsSync(this.pluginsDir)) return [];
+    const store = this.loadTrustStore();
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(this.pluginsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const name = entry.name;
+      if (this.plugins.has(name) || this.isDevTrustExempt(name)) continue;
+      const known = store[name];
+      if (!known) continue;
+      let current: string | undefined;
+      try {
+        current = this.hashFile(path.join(this.pluginsDir, name, 'index.js'));
+      } catch {
+        current = undefined;
+      }
+      if (current !== known.hash) out.push(name);
+    }
+    return out;
   }
 
   /**
@@ -594,8 +701,11 @@ module.exports = {
    */
   getPluginListFormatted(): string {
     const plugins = this.getPlugins();
-    
-    if (plugins.length === 0) {
+    // Plugins whose code changed refuse to load, so they are absent from the
+    // loaded set — list them explicitly so the trust state is visible (#137).
+    const changed = this.getChangedPluginDirs();
+
+    if (plugins.length === 0 && changed.length === 0) {
       return `No plugins installed.
 
 To create a plugin:
@@ -605,13 +715,18 @@ Plugins directory: ${this.pluginsDir}`;
     }
 
     const lines = ['Installed Plugins:', ''];
-    
+
     for (const p of plugins) {
       const status = p.error ? '❌' : p.enabled ? '✅' : '⏸️';
       const version = p.plugin.metadata.version;
       const toolCount = p.plugin.tools?.length || 0;
-      
-      lines.push(`${status} ${p.id} v${version}`);
+      const t = this.getPluginTrustState(p.id);
+      const trustLabel =
+        t.trust === 'pinned' ? t.fingerprint! :
+        t.trust === 'dev' ? 'dev, unverified' :
+        t.trust.toUpperCase();
+
+      lines.push(`${status} ${p.id} v${version}  [${trustLabel}]`);
       lines.push(`   ${p.plugin.metadata.description}`);
       if (toolCount > 0) {
         lines.push(`   Tools: ${p.plugin.tools!.map(t => t.name).join(', ')}`);
@@ -619,6 +734,12 @@ Plugins directory: ${this.pluginsDir}`;
       if (p.error) {
         lines.push(`   Error: ${p.error}`);
       }
+      lines.push('');
+    }
+
+    for (const name of changed) {
+      lines.push(`⚠️  ${name}  [CHANGED]`);
+      lines.push('   Entry file changed since it was trusted — refusing to load. Reinstall or re-trust to load again.');
       lines.push('');
     }
 

--- a/src/runlog.ts
+++ b/src/runlog.ts
@@ -484,6 +484,41 @@ export class RunLog {
 }
 
 /**
+ * Record a supply-chain integrity violation (#137) as a `policy_event` in a
+ * dedicated `security` audit trace. Called when an installed skill or plugin
+ * fails hash re-verification at load time: the artifact is refused AND the
+ * tamper is surfaced in the audit trail, so it is not lost to a transient
+ * console warning that scrolls away.
+ *
+ * `subject` identifies the artifact (e.g. `skill:foo`, `plugin:bar`). Self-gates
+ * on the audit setting: when audit is disabled the underlying RunLog no-ops, so
+ * "log a policy_event if audit is on" needs no extra branch at the call site.
+ * Never throws — auditing must never break the load path it observes.
+ *
+ * Returns the RunLog so callers/tests can await `.flush()`, or null if the
+ * trace could not be opened.
+ */
+export function auditIntegrityViolation(
+  subject: string,
+  reason: string,
+  overrides: Partial<AuditSettings> = {},
+): RunLog | null {
+  try {
+    const log = RunLog.open('security', overrides);
+    log.policyEvent({
+      tool: subject,
+      decision: 'deny',
+      source: 'integrity',
+      reason,
+      durationMs: 0,
+    });
+    return log;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Clear the in-memory instance cache (tests only). Does not touch disk.
  */
 export function resetRunLogs(): void {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as https from 'https';
 import * as crypto from 'crypto';
+import { auditIntegrityViolation } from './runlog.js';
 
 // Skills storage directory
 const SKILLS_DIR = path.join(os.homedir(), '.calliope-cli', 'skills');
@@ -28,6 +29,14 @@ export interface SkillMetadata {
   [key: string]: string | string[] | Record<string, string> | undefined;
 }
 
+/**
+ * Trust state of an installed skill relative to the sha256 pinned at install (#137).
+ *  - `pinned`     — on-disk SKILL.md matches the recorded hash.
+ *  - `changed`    — hash recorded but the file no longer matches (tampered/edited).
+ *  - `unverified` — no hash recorded (legacy entry installed before pinning).
+ */
+export type SkillTrust = 'pinned' | 'changed' | 'unverified';
+
 export interface Skill {
   id: string;
   path: string;
@@ -36,6 +45,29 @@ export interface Skill {
   loaded: boolean;
   source: 'local' | 'registry' | 'github';
   sourceUrl?: string;
+  /** Short sha256 fingerprint pinned at install time, e.g. `sha256:1a2b3c4d5e6f` (#137). */
+  fingerprint?: string;
+  /** Trust state relative to the pinned hash (#137). */
+  trust?: SkillTrust;
+}
+
+/** A skill's install-registry entry (~/.calliope-cli/skills/index.json). */
+interface SkillIndexEntry {
+  path: string;
+  source: string;
+  sourceUrl?: string;
+  /** Full sha256 of SKILL.md recorded at install for trust-on-first-use (#137). */
+  hash?: string;
+}
+
+/** Trust state + pinned fingerprint for an installed skill, for listing surfaces (#137). */
+export interface SkillListing {
+  name: string;
+  description: string;
+  source: 'local' | 'registry' | 'github';
+  sourceUrl?: string;
+  trust: SkillTrust;
+  fingerprint?: string;
 }
 
 export interface SkillReference {
@@ -53,6 +85,16 @@ export interface SkillInstallConfirmation {
   source: 'registry' | 'github';
   sourceUrl: string;
   description: string;
+  /**
+   * `first-install` for a name not yet in the registry; `content-changed` when
+   * re-installing over an existing pin whose hash differs — an explicit update
+   * that must be re-confirmed rather than silently re-pinned (#137).
+   */
+  reason: 'first-install' | 'content-changed';
+  /** Short fingerprint of the incoming content (#137). */
+  fingerprint: string;
+  /** Previous pinned fingerprint, present only when reason is `content-changed` (#137). */
+  previousFingerprint?: string;
 }
 
 // ============================================================================
@@ -87,6 +129,24 @@ function resolveSkillDir(name: string): string {
 function hashContent(content: string): string {
   return crypto.createHash('sha256').update(content).digest('hex');
 }
+
+/** Short, human-comparable fingerprint of a full sha256 hex digest (#137). */
+function fingerprint(hash: string): string {
+  return `sha256:${hash.slice(0, 12)}`;
+}
+
+/** sha256 of a skill directory's SKILL.md, or undefined if unreadable (#137). */
+function hashSkillFile(skillDir: string): string | undefined {
+  try {
+    return hashContent(fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8'));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Shared reason string for a load-time integrity refusal (#137). */
+const MISMATCH_REASON =
+  'SKILL.md content changed since install — refusing to load (re-install to re-trust)';
 
 // Optional confirmation handler for network installs (#137). When unset,
 // installs proceed (backward-compatible). Wire an interactive prompt to gate.
@@ -127,7 +187,7 @@ function getSkillsIndexFile(): string {
 /**
  * Load skills index
  */
-function loadSkillsIndex(): Record<string, { path: string; source: string; sourceUrl?: string; hash?: string }> {
+function loadSkillsIndex(): Record<string, SkillIndexEntry> {
   const file = getSkillsIndexFile();
   if (!fs.existsSync(file)) {
     return {};
@@ -142,7 +202,7 @@ function loadSkillsIndex(): Record<string, { path: string; source: string; sourc
 /**
  * Save skills index
  */
-function saveSkillsIndex(index: Record<string, { path: string; source: string; sourceUrl?: string; hash?: string }>): void {
+function saveSkillsIndex(index: Record<string, SkillIndexEntry>): void {
   ensureSkillsDir();
   fs.writeFileSync(getSkillsIndexFile(), JSON.stringify(index, null, 2));
 }
@@ -264,17 +324,54 @@ export function getSkills(): Skill[] {
     // time — do not silently elevate tampered content into the system prompt (#137).
     if (info.hash && !verifySkillHash(info.path, info.hash)) {
       console.warn(`Skill ${name}: SKILL.md hash mismatch — skipping (re-install to trust again)`);
+      auditIntegrityViolation(`skill:${name}`, MISMATCH_REASON);
       continue;
     }
     const skill = loadSkillFromDir(info.path);
     if (skill) {
       skill.source = info.source as 'local' | 'registry' | 'github';
       skill.sourceUrl = info.sourceUrl;
+      skill.fingerprint = info.hash ? fingerprint(info.hash) : undefined;
+      skill.trust = info.hash ? 'pinned' : 'unverified';
       skills.push(skill);
     }
   }
 
   return skills;
+}
+
+/**
+ * List every installed skill with its trust state and pinned fingerprint (#137).
+ *
+ * Unlike getSkills (which returns only load-safe skills for the system prompt),
+ * this deliberately includes `changed` entries so the /skills surface can warn
+ * the user that content drifted. It does not read instructions or emit audit
+ * events — it is a pure inventory read.
+ */
+export function listSkills(): SkillListing[] {
+  ensureSkillsDir();
+  const index = loadSkillsIndex();
+  const out: SkillListing[] = [];
+
+  for (const [name, info] of Object.entries(index)) {
+    let trust: SkillTrust;
+    if (!info.hash) {
+      trust = 'unverified';
+    } else {
+      trust = verifySkillHash(info.path, info.hash) ? 'pinned' : 'changed';
+    }
+    const skill = loadSkillFromDir(info.path);
+    out.push({
+      name,
+      description: skill?.metadata.description ?? '',
+      source: info.source as 'local' | 'registry' | 'github',
+      sourceUrl: info.sourceUrl,
+      trust,
+      fingerprint: info.hash ? fingerprint(info.hash) : undefined,
+    });
+  }
+
+  return out;
 }
 
 /**
@@ -300,6 +397,7 @@ export function getSkill(name: string): Skill | null {
   // Refuse to surface tampered instructions on activation (#137).
   if (info.hash && !verifySkillHash(info.path, info.hash)) {
     console.warn(`Skill ${name}: SKILL.md hash mismatch — refusing to load (re-install to trust again)`);
+    auditIntegrityViolation(`skill:${name}`, MISMATCH_REASON);
     return null;
   }
 
@@ -307,6 +405,8 @@ export function getSkill(name: string): Skill | null {
   if (skill) {
     skill.source = info.source as 'local' | 'registry' | 'github';
     skill.sourceUrl = info.sourceUrl;
+    skill.fingerprint = info.hash ? fingerprint(info.hash) : undefined;
+    skill.trust = info.hash ? 'pinned' : 'unverified';
   }
   return skill;
 }
@@ -356,12 +456,17 @@ export function installLocalSkill(dir: string): Skill | null {
   // Copy skill directory
   copyDir(dir, destDir);
 
+  // Pin the copied SKILL.md so later on-disk tampering is caught on load (#137).
+  const hash = hashSkillFile(destDir);
+
   // Update index
   const index = loadSkillsIndex();
-  index[skill.id] = { path: destDir, source: 'local' };
+  index[skill.id] = { path: destDir, source: 'local', hash };
   saveSkillsIndex(index);
 
   skill.path = destDir;
+  skill.fingerprint = hash ? fingerprint(hash) : undefined;
+  skill.trust = hash ? 'pinned' : 'unverified';
   return skill;
 }
 
@@ -389,12 +494,23 @@ export async function installFromGithub(url: string): Promise<Skill | null> {
   // Reject path-traversal names from remote, attacker-controlled content (#136).
   const destDir = resolveSkillDir(parsed.metadata.name);
 
+  // Pin the incoming content. If a differently-hashed pin already exists this is
+  // an explicit update, confirmed with the old→new fingerprint diff below — the
+  // registry entry is never re-pinned silently (#137).
+  const newHash = hashContent(content);
+  const index = loadSkillsIndex();
+  const existing = index[parsed.metadata.name];
+  const changed = !!(existing?.hash && existing.hash !== newHash);
+
   // Require explicit confirmation before trusting network content (#137).
   await confirmInstall({
     name: parsed.metadata.name,
     source: 'github',
     sourceUrl: url,
     description: parsed.metadata.description,
+    reason: changed ? 'content-changed' : 'first-install',
+    fingerprint: fingerprint(newHash),
+    previousFingerprint: existing?.hash ? fingerprint(existing.hash) : undefined,
   });
 
   ensureSkillsDir();
@@ -408,8 +524,7 @@ export async function installFromGithub(url: string): Promise<Skill | null> {
   fs.writeFileSync(path.join(destDir, 'SKILL.md'), content);
 
   // Update index (record content hash for trust-on-first-use re-verification — #137)
-  const index = loadSkillsIndex();
-  index[parsed.metadata.name] = { path: destDir, source: 'github', sourceUrl: url, hash: hashContent(content) };
+  index[parsed.metadata.name] = { path: destDir, source: 'github', sourceUrl: url, hash: newHash };
   saveSkillsIndex(index);
 
   return {
@@ -420,6 +535,8 @@ export async function installFromGithub(url: string): Promise<Skill | null> {
     loaded: true,
     source: 'github',
     sourceUrl: url,
+    fingerprint: fingerprint(newHash),
+    trust: 'pinned',
   };
 }
 
@@ -445,12 +562,22 @@ export async function installFromRegistry(skillName: string): Promise<Skill | nu
         throw new Error('Invalid skill content');
       }
 
+      // Pin the incoming content; a differently-hashed existing pin is an
+      // explicit, re-confirmed update rather than a silent re-pin (#137).
+      const newHash = hashContent(info.content);
+      const index = loadSkillsIndex();
+      const existing = index[skillName];
+      const changed = !!(existing?.hash && existing.hash !== newHash);
+
       // Require explicit confirmation before trusting network content (#137).
       await confirmInstall({
         name: skillName,
         source: 'registry',
         sourceUrl: registryUrl,
         description: parsed.metadata.description,
+        reason: changed ? 'content-changed' : 'first-install',
+        fingerprint: fingerprint(newHash),
+        previousFingerprint: existing?.hash ? fingerprint(existing.hash) : undefined,
       });
 
       ensureSkillsDir();
@@ -461,8 +588,7 @@ export async function installFromRegistry(skillName: string): Promise<Skill | nu
 
       fs.writeFileSync(path.join(destDir, 'SKILL.md'), info.content);
 
-      const index = loadSkillsIndex();
-      index[skillName] = { path: destDir, source: 'registry', sourceUrl: registryUrl, hash: hashContent(info.content) };
+      index[skillName] = { path: destDir, source: 'registry', sourceUrl: registryUrl, hash: newHash };
       saveSkillsIndex(index);
 
       return {
@@ -473,6 +599,8 @@ export async function installFromRegistry(skillName: string): Promise<Skill | nu
         loaded: true,
         source: 'registry',
         sourceUrl: registryUrl,
+        fingerprint: fingerprint(newHash),
+        trust: 'pinned',
       };
     }
 

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -687,19 +687,30 @@ Stop a running loop with /loop stop`);
     case '/skills': {
       const subCmd = parts[1];
       if (subCmd === 'list' || !subCmd) {
-        const allSkills = skills.getSkills();
-        if (allSkills.length === 0) {
+        // Show every installed skill with its trust state (#137) — including
+        // CHANGED entries that getSkills() withholds from the model.
+        const listed = skills.listSkills();
+        if (listed.length === 0) {
           ctx.addMessage('system', 'No skills installed.\n\nUsage:\n  /skills add <name>     - Install from agentskills.io\n  /skills add <github-url> - Install from GitHub\n  /skills add <path>     - Install from local directory');
         } else {
-          const list = allSkills.map(s => {
+          const list = listed.map(s => {
             const src = s.source === 'github' ? '(GitHub)' : s.source === 'registry' ? '(agentskills.io)' : '(local)';
-            return `• ${s.metadata.name} ${src}\n  ${s.metadata.description.substring(0, 80)}...`;
+            const trust =
+              s.trust === 'pinned' ? (s.fingerprint ?? 'pinned') :
+              s.trust === 'changed' ? 'CHANGED — reinstall to re-trust' :
+              'UNVERIFIED';
+            const desc = s.description ? `${s.description.substring(0, 80)}...` : '';
+            return `• ${s.name} ${src} [${trust}]\n  ${desc}`;
           }).join('\n\n');
           ctx.addMessage('system', `Installed Skills:\n\n${list}`);
         }
       } else if (subCmd === 'add' && parts[2]) {
         const source = parts[2];
         ctx.addMessage('system', `Installing skill: ${source}...`);
+        // Snapshot pinned fingerprints so a re-install can show old→new rather
+        // than re-pinning silently (#137). The remote name is only known after
+        // the fetch, so we key the lookup by the returned skill's name.
+        const priorFingerprints = new Map(skills.listSkills().map(s => [s.name, s.fingerprint]));
         try {
           let skill;
           if (source.startsWith('http')) {
@@ -710,7 +721,13 @@ Stop a running loop with /loop stop`);
             skill = await skills.installFromRegistry(source);
           }
           if (skill) {
-            ctx.addMessage('system', `✓ Installed: ${skill.metadata.name}`);
+            const prev = priorFingerprints.get(skill.metadata.name);
+            const now = skill.fingerprint ?? '(unverified)';
+            if (prev && prev !== skill.fingerprint) {
+              ctx.addMessage('system', `✓ Re-pinned ${skill.metadata.name}: ${prev} → ${now} (content updated)`);
+            } else {
+              ctx.addMessage('system', `✓ Installed ${skill.metadata.name} — pinned ${now} (trust-on-first-use)`);
+            }
           } else {
             ctx.addMessage('error', 'Failed to install skill');
           }
@@ -731,9 +748,17 @@ Stop a running loop with /loop stop`);
           if (skill.metadata.compatibility) info += `Compatibility: ${skill.metadata.compatibility}\n`;
           if (skill.metadata.license) info += `License: ${skill.metadata.license}\n`;
           if (skill.sourceUrl) info += `Source: ${skill.sourceUrl}\n`;
+          info += skill.fingerprint ? `Fingerprint: ${skill.fingerprint} (${skill.trust})\n` : 'Fingerprint: none (UNVERIFIED)\n';
           ctx.addMessage('system', info);
         } else {
-          ctx.addMessage('error', 'Skill not found');
+          // getSkill withholds a tampered skill; surface WHY, not a bare
+          // "not found", so the trust state stays visible (#137).
+          const changed = skills.listSkills().find(s => s.name === parts[2] && s.trust === 'changed');
+          if (changed) {
+            ctx.addMessage('error', `Skill "${parts[2]}" CHANGED since install (pinned ${changed.fingerprint}) — content no longer matches. Reinstall to re-trust.`);
+          } else {
+            ctx.addMessage('error', 'Skill not found');
+          }
         }
       } else {
         ctx.addMessage('system', 'Usage: /skills [list|add <source>|remove <name>|info <name>]');

--- a/tests/skills-security.test.ts
+++ b/tests/skills-security.test.ts
@@ -41,6 +41,7 @@ import {
   installFromRegistry,
   getSkill,
   getSkills,
+  listSkills,
   setSkillInstallConfirmHandler,
   uninstallSkill,
   type SkillInstallConfirmation,
@@ -52,7 +53,22 @@ import {
   type PluginTrustConfirmation,
 } from '../src/plugins.js';
 
+import * as config from '../src/config.js';
+import { RunLog, runLogPath, resolveAuditSettings } from '../src/runlog.js';
+
 const SKILLS_DIR = path.join(os.homedir(), '.calliope-cli', 'skills');
+
+/** Flush the shared `security` audit trace and return its parsed lines (#137). */
+async function readSecurityEvents(): Promise<Array<Record<string, unknown>>> {
+  await RunLog.open('security').flush();
+  const p = runLogPath('security', resolveAuditSettings().dir);
+  if (!fs.existsSync(p)) return [];
+  return fs
+    .readFileSync(p, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
 
 function queueHttp(...bodies: string[]): void {
   httpState.responses = bodies;
@@ -288,5 +304,313 @@ describe('#137 plugin trust gate', () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.enabled).toBe(true);
     expect(seen[0]?.reason).toBe('entry-file-changed');
+  });
+});
+
+// ===========================================================================
+// #137 — skill pin-on-install, fingerprint, and trust listing
+// ===========================================================================
+
+describe('#137 skill pin-on-install + trust listing', () => {
+  const NAME = '__sec-pin-skill__';
+  afterEach(() => cleanupSkill(NAME));
+
+  it('records a stable sha256 fingerprint on a network install (TOFU)', async () => {
+    queueHttp(`---\nname: ${NAME}\ndescription: d\n---\n\n# body\n`);
+    const skill = await installFromGithub('https://github.com/u/r/tree/main/skill');
+    expect(skill!.fingerprint).toMatch(/^sha256:[0-9a-f]{12}$/);
+    expect(skill!.trust).toBe('pinned');
+
+    // The same fingerprint is re-surfaced on load.
+    const again = getSkill(NAME);
+    expect(again!.fingerprint).toBe(skill!.fingerprint);
+    expect(again!.trust).toBe('pinned');
+  });
+
+  it('pins a registry (content) install with a fingerprint', async () => {
+    queueHttp(JSON.stringify({ content: `---\nname: ${NAME}\ndescription: reg\n---\n\n# body\n` }));
+    const skill = await installFromRegistry(NAME);
+    expect(skill!.fingerprint).toMatch(/^sha256:[0-9a-f]{12}$/);
+    expect(skill!.trust).toBe('pinned');
+    expect(getSkill(NAME)!.trust).toBe('pinned');
+  });
+
+  it('pins a local skill install and lists it as pinned', () => {
+    const srcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-pin-local-'));
+    fs.writeFileSync(
+      path.join(srcDir, 'SKILL.md'),
+      `---\nname: ${NAME}\ndescription: local d\n---\n\n# body\n`
+    );
+    const skill = installLocalSkill(srcDir);
+    expect(skill!.trust).toBe('pinned');
+    expect(skill!.fingerprint).toMatch(/^sha256:/);
+
+    const entry = listSkills().find((s) => s.name === NAME);
+    expect(entry?.trust).toBe('pinned');
+    expect(entry?.fingerprint).toBe(skill!.fingerprint);
+
+    fs.rmSync(srcDir, { recursive: true, force: true });
+  });
+
+  it('load-verify passes repeatedly while content is unchanged', async () => {
+    queueHttp(`---\nname: ${NAME}\ndescription: d\n---\n\n# body\n`);
+    await installFromGithub('https://github.com/u/r/tree/main/skill');
+    expect(getSkill(NAME)).not.toBeNull();
+    expect(getSkill(NAME)).not.toBeNull();
+    expect(listSkills().find((s) => s.name === NAME)?.trust).toBe('pinned');
+  });
+
+  it('lists a tampered skill as CHANGED instead of dropping it silently', async () => {
+    queueHttp(`---\nname: ${NAME}\ndescription: d\n---\n\n# body\n`);
+    await installFromGithub('https://github.com/u/r/tree/main/skill');
+    fs.writeFileSync(
+      path.join(SKILLS_DIR, NAME, 'SKILL.md'),
+      `---\nname: ${NAME}\ndescription: hijacked\n---\n\n# evil\n`
+    );
+
+    const entry = listSkills().find((s) => s.name === NAME);
+    expect(entry?.trust).toBe('changed');
+
+    // getSkills (prompt-facing) still withholds the tampered skill.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(getSkills().find((s) => s.metadata.name === NAME)).toBeUndefined();
+    warn.mockRestore();
+  });
+});
+
+// ===========================================================================
+// #137 — skill update flow: explicit re-pin, never silent
+// ===========================================================================
+
+describe('#137 skill update flow (explicit re-pin)', () => {
+  const NAME = '__sec-update-skill__';
+  afterEach(() => cleanupSkill(NAME));
+
+  it('re-install with changed content confirms as content-changed with old→new fingerprints', async () => {
+    queueHttp(`---\nname: ${NAME}\ndescription: v1\n---\n\n# one\n`);
+    const v1 = await installFromGithub('https://github.com/u/r/tree/main/skill');
+
+    const seen: SkillInstallConfirmation[] = [];
+    setSkillInstallConfirmHandler((info) => { seen.push(info); return true; });
+
+    queueHttp(`---\nname: ${NAME}\ndescription: v2\n---\n\n# two changed\n`);
+    const v2 = await installFromGithub('https://github.com/u/r/tree/main/skill');
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].reason).toBe('content-changed');
+    expect(seen[0].previousFingerprint).toBe(v1!.fingerprint);
+    expect(seen[0].fingerprint).toBe(v2!.fingerprint);
+    expect(v2!.fingerprint).not.toBe(v1!.fingerprint);
+    // The new content is what loads now.
+    expect(getSkill(NAME)!.metadata.description).toBe('v2');
+  });
+
+  it('a declined content-change leaves the original pin intact (no silent re-pin)', async () => {
+    queueHttp(`---\nname: ${NAME}\ndescription: v1\n---\n\n# one\n`);
+    const v1 = await installFromGithub('https://github.com/u/r/tree/main/skill');
+
+    // Approve first-install but reject content-changes.
+    setSkillInstallConfirmHandler((info) => info.reason !== 'content-changed');
+
+    queueHttp(`---\nname: ${NAME}\ndescription: v2\n---\n\n# two\n`);
+    await expect(
+      installFromGithub('https://github.com/u/r/tree/main/skill')
+    ).rejects.toThrow(/declined/);
+
+    // Still pinned to v1: content and fingerprint unchanged.
+    const cur = getSkill(NAME);
+    expect(cur!.metadata.description).toBe('v1');
+    expect(cur!.fingerprint).toBe(v1!.fingerprint);
+  });
+
+  it('re-install with identical content is not treated as a change', async () => {
+    const body = `---\nname: ${NAME}\ndescription: same\n---\n\n# same\n`;
+    queueHttp(body);
+    const v1 = await installFromGithub('https://github.com/u/r/tree/main/skill');
+
+    const seen: SkillInstallConfirmation[] = [];
+    setSkillInstallConfirmHandler((info) => { seen.push(info); return true; });
+    queueHttp(body);
+    const v1b = await installFromGithub('https://github.com/u/r/tree/main/skill');
+
+    expect(seen[0].reason).toBe('first-install');
+    expect(v1b!.fingerprint).toBe(v1!.fingerprint);
+  });
+});
+
+// ===========================================================================
+// #137 — skill integrity audit (policy_event)
+// ===========================================================================
+
+describe('#137 skill integrity audit', () => {
+  const NAME = '__sec-audit-skill__';
+  afterEach(() => cleanupSkill(NAME));
+
+  it('emits a deny policy_event when a tampered skill is refused at load', async () => {
+    queueHttp(`---\nname: ${NAME}\ndescription: d\n---\n\n# body\n`);
+    await installFromGithub('https://github.com/u/r/tree/main/skill');
+    fs.writeFileSync(
+      path.join(SKILLS_DIR, NAME, 'SKILL.md'),
+      `---\nname: ${NAME}\ndescription: hijacked\n---\n\n# evil\n`
+    );
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(getSkill(NAME)).toBeNull();
+    warn.mockRestore();
+
+    const mine = (await readSecurityEvents()).filter(
+      (e) => e.type === 'policy_event' && e.tool === `skill:${NAME}`
+    );
+    expect(mine.length).toBeGreaterThanOrEqual(1);
+    expect(mine[mine.length - 1].decision).toBe('deny');
+    expect(mine[mine.length - 1].source).toBe('integrity');
+  });
+});
+
+// ===========================================================================
+// #137 — plugin dev exemption, trust listing, and integrity audit
+// ===========================================================================
+
+describe('#137 plugin trust state, listing, dev exemption + audit', () => {
+  let tmpRoot: string;
+  let pluginsDir: string;
+  let origDir: string;
+
+  function makePlugin(name: string, indexJs: string): void {
+    const dir = path.join(pluginsDir, name);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'plugin.json'),
+      JSON.stringify({ name, version: '1.0.0', description: 'dev/trust test' })
+    );
+    fs.writeFileSync(path.join(dir, 'index.js'), indexJs);
+  }
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'calliope-plugin-trust-'));
+    pluginsDir = path.join(tmpRoot, 'plugins');
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    origDir = (pluginManager as any).pluginsDir;
+    (pluginManager as any).pluginsDir = pluginsDir;
+    (pluginManager as any).plugins.clear();
+    setPluginTrustConfirmHandler(null);
+    delete process.env.CALLIOPE_PLUGIN_DEV;
+    config.set('plugins', {});
+  });
+
+  afterEach(() => {
+    delete process.env.CALLIOPE_PLUGIN_DEV;
+    config.set('plugins', {});
+    setPluginTrustConfirmHandler(null);
+    (pluginManager as any).pluginsDir = origDir;
+    (pluginManager as any).plugins.clear();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('pins a normal plugin and is not dev-exempt by default', () => {
+    makePlugin('plain-plugin', `module.exports = { tools: [] };`);
+    expect(pluginManager.getPluginTrustState('plain-plugin').trust).toBe('unverified');
+  });
+
+  it('CALLIOPE_PLUGIN_DEV exempts a live-edited plugin from re-trust', async () => {
+    process.env.CALLIOPE_PLUGIN_DEV = '1';
+    makePlugin('dev-plugin', `module.exports = { tools: [] };`);
+
+    const first = await pluginManager.loadPlugin('dev-plugin');
+    expect(first).not.toBeNull();
+    expect(pluginManager.getPluginTrustState('dev-plugin').trust).toBe('dev');
+
+    // Edit the entry file: a pinned plugin would refuse; a dev plugin reloads.
+    fs.writeFileSync(
+      path.join(pluginsDir, 'dev-plugin', 'index.js'),
+      `module.exports = { tools: [], metadata: { description: 'edited' } };`
+    );
+    (pluginManager as any).plugins.clear();
+    const second = await pluginManager.loadPlugin('dev-plugin');
+    expect(second).not.toBeNull();
+    expect(second!.enabled).toBe(true);
+
+    // No pin is written for an exempted plugin.
+    expect(fs.existsSync(path.join(pluginsDir, 'trust.json'))).toBe(false);
+  });
+
+  it('plugins.devTrustLocal config exempts only the named plugin', async () => {
+    config.set('plugins', { devTrustLocal: ['listed-dev'] });
+    makePlugin('listed-dev', `module.exports = { tools: [] };`);
+    makePlugin('other-plugin', `module.exports = { tools: [] };`);
+
+    expect(pluginManager.getPluginTrustState('listed-dev').trust).toBe('dev');
+    expect(pluginManager.getPluginTrustState('other-plugin').trust).toBe('unverified');
+
+    const loaded = await pluginManager.loadPlugin('listed-dev');
+    expect(loaded).not.toBeNull();
+  });
+
+  it('a plugin cannot exempt itself via its own manifest', () => {
+    // A self-declared `dev` field in plugin.json must not grant exemption.
+    const dir = path.join(pluginsDir, 'sneaky');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'plugin.json'),
+      JSON.stringify({ name: 'sneaky', version: '1.0.0', description: 'x', dev: true, devTrustLocal: ['sneaky'] })
+    );
+    fs.writeFileSync(path.join(dir, 'index.js'), `module.exports = { tools: [] };`);
+
+    expect(pluginManager.getPluginTrustState('sneaky').trust).toBe('unverified');
+  });
+
+  it('shows the pinned fingerprint for a loaded plugin in the listing', async () => {
+    makePlugin('listed', `module.exports = { tools: [] };`);
+    await pluginManager.loadPlugin('listed');
+
+    const state = pluginManager.getPluginTrustState('listed');
+    expect(state.trust).toBe('pinned');
+    expect(state.fingerprint).toMatch(/^sha256:/);
+
+    const formatted = pluginManager.getPluginListFormatted();
+    expect(formatted).toContain('listed');
+    expect(formatted).toContain(state.fingerprint!);
+  });
+
+  it('reports a changed-but-present plugin as CHANGED in the listing', async () => {
+    makePlugin('mutant', `module.exports = { tools: [] };`);
+    await pluginManager.loadPlugin('mutant');
+
+    // Tamper and drop from the loaded set, as a fresh session would.
+    fs.writeFileSync(
+      path.join(pluginsDir, 'mutant', 'index.js'),
+      `module.exports = { init: async () => {} };`
+    );
+    (pluginManager as any).plugins.clear();
+
+    expect(pluginManager.getPluginTrustState('mutant').trust).toBe('changed');
+    const formatted = pluginManager.getPluginListFormatted();
+    expect(formatted).toContain('mutant');
+    expect(formatted).toContain('CHANGED');
+  });
+
+  it('emits a deny policy_event when a changed plugin is refused at load', async () => {
+    makePlugin('audited-plugin', `module.exports = { tools: [] };`);
+    await pluginManager.loadPlugin('audited-plugin');
+
+    fs.writeFileSync(
+      path.join(pluginsDir, 'audited-plugin', 'index.js'),
+      `module.exports = { init: async () => { globalThis.__SEC_AUDIT = true; } };`
+    );
+    (globalThis as any).__SEC_AUDIT = false;
+    (pluginManager as any).plugins.clear();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const second = await pluginManager.loadPlugin('audited-plugin');
+    warn.mockRestore();
+
+    expect(second).toBeNull();
+    expect((globalThis as any).__SEC_AUDIT).toBe(false);
+
+    const mine = (await readSecurityEvents()).filter(
+      (e) => e.type === 'policy_event' && e.tool === 'plugin:audited-plugin'
+    );
+    expect(mine.length).toBeGreaterThanOrEqual(1);
+    expect(mine[mine.length - 1].source).toBe('integrity');
   });
 });


### PR DESCRIPTION
## Summary
Completes the TOFU trust model that #136/#137 groundwork started:
- Visible sha256 fingerprints on install, first-load, and in /skills + plugin listings (or UNVERIFIED/CHANGED/dev labels); changed plugins listed explicitly instead of silently vanishing
- No silent re-pinning: re-installs classify first-install vs content-changed and show an old→new fingerprint diff through the confirm gate
- Tamper refusals emit a deny policy_event (source: integrity) to a dedicated security run-log
- Local skill installs now pinned like network ones; plugin dev exemption via CALLIOPE_PLUGIN_DEV or plugins.devTrustLocal (user-side only — a plugin cannot self-exempt)
- docs/security.md documents the model and its explicit limits: TOFU does not defend the first install (needs signing — #223); only SKILL.md/index.js are hashed
- Review note: skills/plugins are half-wired into the live app (initPlugins/getSkillsContext not on the main path) — this hardens the mechanism; end-to-end wiring is separate scope

## Test Plan
- Security suite 15 → 34 tests (pin, verify, tamper-refuse+audit, re-pin diff, declined-change, dev exemption, self-exempt rejected)
- npm test: 3,739 passed, 4 skipped (111 files); coverage 93.9%; bench PASS

Fixes #137