### PR TITLE
Stub AWS CLI spawns in bedrock tests

### DIFF
--- a/tests/bedrock-extended.test.ts
+++ b/tests/bedrock-extended.test.ts
@@ -26,6 +26,17 @@ import * as fs from 'fs';
 // Mocks
 // ---------------------------------------------------------------------------
 
+// The no-credentials path shells out to the AWS CLI (twice, 10s timeout each)
+// via a dynamic import of child_process. Real spawns are nondeterministic on
+// CI runners that have the AWS CLI installed — stub them to fail instantly.
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(() => {
+    const err = new Error('spawn aws ENOENT') as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    throw err;
+  }),
+}));
+
 vi.mock('../src/config.js', () => ({
   default: {},
   get: vi.fn(),

--- a/tests/bedrock.test.ts
+++ b/tests/bedrock.test.ts
@@ -16,6 +16,17 @@ import * as fs from 'fs';
 // Mocks — must be set up before importing the module under test
 // ---------------------------------------------------------------------------
 
+// The no-credentials path shells out to the AWS CLI (twice, 10s timeout each)
+// via a dynamic import of child_process. Real spawns are nondeterministic on
+// CI runners that have the AWS CLI installed — stub them to fail instantly.
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(() => {
+    const err = new Error('spawn aws ENOENT') as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    throw err;
+  }),
+}));
+
 vi.mock('../src/config.js', () => ({
   default: {},
   get: vi.fn(),


### PR DESCRIPTION
## Summary
Third and final root cause of #214: bedrock's no-credentials path dynamically imports child_process and runs aws configure export-credentials TWICE with 10s timeouts. GitHub runners ship the AWS CLI, so the test intermittently spawned a real (slow) subprocess and blew its 5s timeout — the store isolation and IMDS env var were necessary but not sufficient. execFileSync is now stubbed to instant ENOENT in both bedrock test files.

## Test Plan
- bedrock + bedrock-extended: 61 passed, instant
- npm test: full suite green

Fixes #214