### PR TITLE
Inject execution directive on plan-to-work transition

### DIFF
--- a/docs/security 2.md
+++ b/docs/security 2.md
@@ -1,0 +1,119 @@
+# Security: skill & plugin trust (TOFU)
+
+Skills and plugins are code and instructions that Calliope runs **in-process**:
+
+- a **plugin**'s `index.js` is `import()`-ed, so its code executes with the full
+  privileges of the CLI;
+- a **skill**'s `SKILL.md` is fed into the model's system prompt, so its text can
+  steer the agent (prompt injection).
+
+Both can be fetched from the network (the agentskills.io registry, a GitHub URL)
+or dropped into `~/.calliope-cli/`. To stop *silent* tampering after you have
+accepted an artifact, Calliope pins a content hash at install time and
+re-verifies it on every load. This is a **trust-on-first-use (TOFU)** model — the
+same shape as SSH host keys.
+
+## What is pinned, and where
+
+| Artifact | Hashed content | Pin store |
+|----------|----------------|-----------|
+| Skill    | `SKILL.md` (sha256) | `~/.calliope-cli/skills/index.json` → entry `hash` |
+| Plugin   | `index.js` (sha256) | `~/.calliope-cli/plugins/trust.json` → entry `hash` |
+
+A short **fingerprint** — `sha256:` plus the first 12 hex characters of the
+digest — is shown wherever trust is surfaced, so you can eyeball it.
+
+## The lifecycle
+
+1. **First install / first load (trust-on-first-use).** The artifact is fetched,
+   its hash recorded, and the fingerprint printed:
+
+   ```
+   ✓ Installed git-workflow — pinned sha256:1a2b3c4d5e6f (trust-on-first-use)
+   Plugin toolbox: trusted on first use — entry-file fingerprint sha256:9f8e7d6c5b4a
+   ```
+
+   Network installs also pass through a confirmation gate before anything is
+   written to disk.
+
+2. **Every subsequent load — verify.** Before a skill enters the prompt or a
+   plugin's code is imported, its on-disk content is re-hashed and compared to
+   the pin. **Match → load. Mismatch → refuse**, with a clear message telling you
+   to reinstall to re-trust. A tampered skill is withheld from the model; a
+   changed plugin is never imported.
+
+3. **Audit.** When audit run logs are on (the default — see
+   [governance](./governance.md)), a refused load is recorded as a `policy_event`
+   with `source: "integrity"` in a dedicated `security` trace, so the tamper is
+   not lost to a console warning that scrolls away.
+
+4. **Update — explicit re-pin, never silent.** Reinstalling an artifact whose
+   content changed is treated as an update: the confirmation shows the
+   `content-changed` reason, and the surface prints the fingerprint diff:
+
+   ```
+   ✓ Re-pinned git-workflow: sha256:1a2b3c4d5e6f → sha256:0099aabbccdd (content updated)
+   ```
+
+   The pin is only replaced through this visible path.
+
+## Trust state in listings
+
+`/skills` and the plugin list annotate every entry with its trust state:
+
+- the pinned **fingerprint** (`sha256:…`) when the content still matches;
+- **`CHANGED`** when the content drifted from its pin (withheld / refused);
+- **`UNVERIFIED`** when no hash was recorded (a legacy entry installed before
+  pinning);
+- **`dev, unverified`** for an exempted local dev plugin (below).
+
+A `CHANGED` plugin refuses to load, so it would otherwise vanish from the list;
+it is listed explicitly so the state is never silently hidden.
+
+## Local dev plugins (exemption)
+
+A plugin you are actively editing would re-prompt on every save. You can exempt
+it from pinning — but **only as a user-side decision**; a plugin can never mark
+itself exempt through its own manifest. Two levers:
+
+- **Env flag** — `CALLIOPE_PLUGIN_DEV=1` exempts *all* plugins for that process
+  (blanket dev mode);
+- **Config allowlist** — name specific plugins in `plugins.devTrustLocal`:
+
+  ```jsonc
+  // ~/.calliope config
+  { "plugins": { "devTrustLocal": ["my-wip-plugin"] } }
+  ```
+
+Exempted plugins load without pinning and are shown as `dev, unverified`. Skills
+installed from a local path are **copied** into the store and pinned like any
+other — the exemption is a plugin-only concern, for live-edited code.
+
+## What TOFU does and does not defend
+
+TOFU defends the window **after** you accept an artifact: it catches later
+tampering (a compromised update, a local edit, accidental drift) and refuses to
+run it.
+
+It explicitly does **not** defend the **first** install. If the registry or the
+GitHub source is already compromised the very first time you fetch, TOFU will
+faithfully pin and trust the malicious content — there is no prior good hash to
+compare against. Closing that gap requires **artifact signing** (verifying a
+publisher signature against a trusted key), tracked in
+[issue #223](https://github.com/calliopeai/calliope-cli/issues/223).
+
+Other limits worth stating plainly:
+
+- **Scope of the hash.** Only `SKILL.md` (skills) and `index.js` (plugins) are
+  hashed. A plugin that `require()`s sibling files, or a skill's `scripts/` and
+  `assets/`, are not covered by the pin. Prefer single-file plugins; treat a
+  skill's scripts as you would any downloaded script.
+- **Transport.** Fetches are plain HTTPS; you are trusting TLS and the registry,
+  not a signature.
+- **Local attacker.** The pin store lives in the same `~/.calliope-cli/` tree it
+  protects. An attacker who already has write access to your home directory can
+  rewrite both the artifact and its pin. TOFU raises the bar against remote and
+  accidental tampering, not against an adversary who already owns your account.
+
+See also: [governance](./governance.md) for the audit run-log format and
+`calliope replay`, and the root [`SECURITY.md`](../SECURITY.md) for reporting.

--- a/src/ui/agent.ts
+++ b/src/ui/agent.ts
@@ -305,6 +305,16 @@ function surfaceResponseWarnings(ctx: AgentContext, response: LLMResponse): void
  * Run agent with user prompt. Core execution loop that handles LLM calls,
  * tool execution (parallel + sequential), auto-compaction, and queued messages.
  */
+// #231: remember the previous turn's mode so the first work-mode turn after
+// a plan-mode turn can carry an explicit execution directive. Module scope is
+// intentional — mode itself outlives session resets.
+let previousTurnMode: string | null = null;
+
+/** Test seam: clear the plan-to-work transition tracking. */
+export function _resetModeTracking(): void {
+  previousTurnMode = null;
+}
+
 export async function runAgentImpl(ctx: AgentContext, content: MessageContent): Promise<void> {
   ctx.debugLog('runAgent', 'ENTER', typeof content === 'string' ? content.substring(0, 50) : '[complex]');
 
@@ -387,6 +397,12 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
     config: config.getConfig() as unknown as Record<string, unknown>,
   });
   runlog.userPrompt(summarizeMessageContent(content));
+
+  // #231: a terse reply right after leaving plan mode is an approval, not a
+  // conversation — bind it to execution explicitly or weak models answer
+  // "done" without doing anything.
+  const justLeftPlanMode = previousTurnMode === 'plan' && ctx.mode !== 'plan';
+  previousTurnMode = ctx.mode;
 
   const finalizeRun = (exitReason: string): void => {
     if (runEnded) return;
@@ -516,6 +532,19 @@ export async function runAgentImpl(ctx: AgentContext, content: MessageContent): 
               + 'Before proposing any plan, read the files you intend to change and cite file:line for every claim. '
               + 'State explicitly what you verified versus what you assume. '
               + 'A plan produced without reading anything will be marked unverified.',
+          },
+        ];
+      }
+
+      if (justLeftPlanMode && i === 0) {
+        validatedMessages = [
+          ...validatedMessages,
+          {
+            role: 'system' as const,
+            content: 'The user has just switched from plan mode to work mode and replied. '
+              + 'Treat their message as approval to execute the plan discussed above. '
+              + 'Carry it out now using tools, step by step. '
+              + 'Never state that work is done unless you performed it with tool calls in this turn.',
           },
         ];
       }

--- a/tests/plan-approval-injection.test.ts
+++ b/tests/plan-approval-injection.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentContext } from '../src/ui/agent.js';
+import type { Message as LLMMessage, LLMProvider, Mode } from '../src/types.js';
+
+const chatMock = vi.fn();
+const saveMessageHistoryMock = vi.fn();
+
+vi.mock('../src/config.js', () => ({
+  default: {},
+  get: vi.fn((key: string) => {
+    if (key === 'maxIterations') return 1;
+    if (key === 'audit') return { enabled: false }; // no run-log disk writes in tests
+    return undefined;
+  }),
+  getConfig: vi.fn(() => ({})),
+}));
+
+vi.mock('../src/providers/index.js', () => ({
+  chat: (...args: unknown[]) => chatMock(...args),
+  getAvailableProviders: vi.fn(() => ['openai', 'google']),
+}));
+
+vi.mock('../src/providers/types.js', () => ({
+  estimateContextUsage: vi.fn(() => ({
+    estimated: 100,
+    limit: 100000,
+    percent: 1,
+    needsSummarization: false,
+  })),
+  needsSummarization: vi.fn(() => false),
+}));
+
+vi.mock('../src/tools.js', () => ({
+  executeTool: vi.fn(),
+  getTools: vi.fn(() => []),
+}));
+
+vi.mock('../src/types.js', () => ({
+  DEFAULT_MODELS: { openai: 'gpt-4o' },
+  RISK_CONFIG: {},
+  calculateCost: vi.fn(() => 0),
+}));
+
+vi.mock('../src/model-detection.js', () => ({
+  getModelContextLimit: vi.fn(() => 100000),
+  getModelMaxOutput: vi.fn(() => 8192),
+}));
+
+vi.mock('../src/risk.js', () => ({
+  assessToolRisk: vi.fn(() => ({ level: 'low', reason: '', canAutoApprove: true })),
+  requiresConfirmation: vi.fn(() => false),
+}));
+
+vi.mock('../src/errors.js', () => ({
+  formatError: vi.fn((error: unknown) => error instanceof Error ? error.message : String(error)),
+  classifyError: vi.fn(() => ({ category: 'other' })),
+}));
+
+vi.mock('../src/storage.js', () => ({
+  saveMessageHistory: (...args: unknown[]) => saveMessageHistoryMock(...args),
+  recordCost: vi.fn(),
+}));
+
+vi.mock('../src/hooks.js', () => ({
+  checkHooksAllow: vi.fn(async () => ({ allowed: true })),
+  executeHooks: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../src/router.js', () => ({
+  routeRequest: vi.fn(),
+  smartRoute: vi.fn(),
+  getDefaultSmartRoutingConfig: vi.fn(() => ({ enabled: false })),
+}));
+
+vi.mock('../src/summarization.js', () => ({
+  validateMessageHistory: vi.fn((messages: unknown[]) => messages),
+  summarizeConversation: vi.fn((messages: unknown[]) => ({
+    messages,
+    summarizedCount: 0,
+    originalTokens: 0,
+    reducedTokens: 0,
+    summary: '',
+  })),
+  estimateTotalTokens: vi.fn(() => 100),
+  summarizeMessages: vi.fn(() => ''),
+}));
+
+vi.mock('../src/parallel-tools.js', () => ({
+  executeParallel: vi.fn(),
+  getParallelizationStats: vi.fn(() => ({
+    totalCalls: 0,
+    parallelCalls: 0,
+    sequentialCalls: 0,
+    stages: 0,
+  })),
+}));
+
+
+vi.mock('../src/ui/context.js', () => ({
+  checkAndWarnContextLimit: vi.fn(),
+}));
+
+vi.mock('../src/circuit-breaker.js', () => ({
+  CircuitBreaker: vi.fn(),
+}));
+
+vi.mock('../src/iteration-ledger.js', () => ({
+  IterationLedger: vi.fn(),
+}));
+
+vi.mock('../src/checkpoint.js', () => ({
+  shouldCheckpoint: vi.fn(() => false),
+  createCheckpoint: vi.fn(),
+}));
+
+
+vi.mock('../src/prevent-sleep.js', () => ({
+  startPreventSleep: vi.fn(),
+  stopPreventSleep: vi.fn(),
+}));
+
+const { runAgentImpl, _resetModeTracking } = await import('../src/ui/agent.js');
+
+function makeCtx(): AgentContext & { collectedMessages: Array<{ type: string; content: string }> } {
+  const collectedMessages: Array<{ type: string; content: string }> = [];
+  const llmMessages: LLMMessage[] = [];
+
+  const ctx = {
+    provider: 'openai' as LLMProvider,
+    model: 'gpt-4o',
+    mode: 'hybrid' as Mode,
+    confirmMode: false,
+    autoRoute: false,
+    actualProvider: 'openai',
+    actualModel: 'gpt-4o',
+    stats: {
+      messageCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+    },
+
+    setStats: vi.fn((value: unknown) => {
+      if (typeof value === 'function') {
+        ctx.stats = value(ctx.stats);
+      } else {
+        ctx.stats = value as AgentContext['stats'];
+      }
+    }),
+    setStreamingResponse: vi.fn(),
+    setThinkingState: vi.fn(),
+    setActivityState: vi.fn(),
+    setContextTokens: vi.fn(),
+    setIsProcessing: vi.fn(),
+    setQueuedMessages: vi.fn(),
+    setEditingQueueIndex: vi.fn(),
+    setLoopIteration: vi.fn(),
+    setLoopActive: vi.fn(),
+
+    llmMessages: { current: llmMessages },
+    queuedMessagesRef: { current: [] as string[] },
+    loopCancelledRef: { current: false },
+    sessionRef: { current: null },
+
+    addMessage: (type: 'user' | 'assistant' | 'tool' | 'system' | 'error', content: string) => {
+      collectedMessages.push({ type, content });
+    },
+    estimateContextTokens: vi.fn(() => 0),
+    validateAndRepairMessages: vi.fn(() => true),
+
+    debugLog: vi.fn(),
+    collectedMessages,
+  } as unknown as AgentContext & { collectedMessages: Array<{ type: string; content: string }> };
+
+  return ctx;
+}
+
+
+
+const APPROVAL_SNIPPET = 'switched from plan mode to work mode';
+
+describe('plan-to-work approval injection (#231)', () => {
+  beforeEach(() => {
+    chatMock.mockReset();
+    saveMessageHistoryMock.mockReset();
+    _resetModeTracking();
+    chatMock.mockResolvedValue({ content: 'ok', toolCalls: [] });
+  });
+
+  it('injects the execution directive on the first work turn after a plan turn', async () => {
+    const planCtx = makeCtx();
+    (planCtx as { mode: string }).mode = 'plan';
+    await runAgentImpl(planCtx, 'plan the work');
+
+    chatMock.mockClear();
+    chatMock.mockResolvedValue({ content: 'executing', toolCalls: [] });
+    const workCtx = makeCtx();
+    (workCtx as { mode: string }).mode = 'work';
+    await runAgentImpl(workCtx, 'go');
+    const msgs = chatMock.mock.calls[0][1] as Array<{ role: string; content: string }>;
+    expect(msgs.some(m => m.role === 'system' && m.content.includes(APPROVAL_SNIPPET))).toBe(true);
+    // transient — not persisted into history
+    expect(workCtx.llmMessages.current.some(m => typeof m.content === 'string' && m.content.includes(APPROVAL_SNIPPET))).toBe(false);
+  });
+
+  it('does not inject on subsequent work turns', async () => {
+    const planCtx = makeCtx();
+    (planCtx as { mode: string }).mode = 'plan';
+    await runAgentImpl(planCtx, 'plan');
+
+    const w1 = makeCtx();
+    (w1 as { mode: string }).mode = 'work';
+    await runAgentImpl(w1, 'go');
+
+    chatMock.mockClear();
+    chatMock.mockResolvedValue({ content: 'more', toolCalls: [] });
+    const w2 = makeCtx();
+    (w2 as { mode: string }).mode = 'work';
+    await runAgentImpl(w2, 'continue');
+    const msgs = chatMock.mock.calls[0][1] as Array<{ role: string; content: string }>;
+    expect(msgs.some(m => m.role === 'system' && m.content.includes(APPROVAL_SNIPPET))).toBe(false);
+  });
+
+  it('does not inject without a preceding plan turn', async () => {
+    const ctx = makeCtx();
+    await runAgentImpl(ctx, 'just do something');
+    const msgs = chatMock.mock.calls[0][1] as Array<{ role: string; content: string }>;
+    expect(msgs.some(m => m.role === 'system' && m.content.includes(APPROVAL_SNIPPET))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Live-test catch #3: grounded plan in plan mode → user switches to work mode → 3-char approval → model replies 'Implemented.' with zero tool calls (audit-verified; prompt delivered, tools offered). The #192 approval flow left the approval turn semantically bare.
- First agent turn after a plan→work transition now injects a transient directive: this message is approval — execute with tools, never claim completion without tool calls this turn
- Module-level previous-mode tracking with a test seam; injection fires exactly once, never persists to history

## Test Plan
- 3 new tests (fires on transition, not on later turns, not without plan); #224 suite unchanged
- npm test: full suite green

Fixes #231