### PR TITLE
Persist model and provider selections as defaults

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -283,6 +283,10 @@ export function set<K extends keyof CalliopeConfig>(key: K, value: CalliopeConfi
 /**
  * Set multiple config values with validation
  */
+export function unset(key: keyof CalliopeConfig): void {
+  (config as unknown as { delete(k: string): void }).delete(key as string);
+}
+
 export function setMultiple(values: Partial<CalliopeConfig>): void {
   // Validate all values first before setting any
   for (const [key, value] of Object.entries(values)) {

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -232,7 +232,11 @@ File references: @filename, ./path, /absolute/path`;
           break;
         }
         ctx.setProvider(requested);
-        ctx.addMessage('system', `Provider: ${selectProvider(requested)}`);
+        // Explicit switches persist as the new defaults; a stale model from
+        // the previous provider must not leak into this one (#233).
+        config.set('defaultProvider', requested);
+        config.unset('defaultModel');
+        ctx.addMessage('system', `Provider: ${selectProvider(requested)} (saved as default)`);
       } else if (parts[1] === 'list') {
         ctx.addMessage('system', `Provider: ${ctx.actualProvider} | Available: ${getAvailableProviders().join(', ')}`);
       } else if (ctx.openProviderPicker) {
@@ -254,6 +258,7 @@ File references: @filename, ./path, /absolute/path`;
         const newPct = Math.round((currentTokens / newLimit) * 100);
 
         ctx.setModel(newModel);
+        config.set('defaultModel', newModel);
         ctx.setContextTokens(currentTokens);
 
         let switchWarning = '';
@@ -262,7 +267,7 @@ File references: @filename, ./path, /absolute/path`;
         } else if (newLimit < oldLimit) {
           switchWarning = `\n📉 Context window: ${Math.round(oldLimit/1000)}K → ${Math.round(newLimit/1000)}K (${newPct}% used)`;
         }
-        ctx.addMessage('system', `Model: ${oldModel} → ${newModel}${switchWarning}`);
+        ctx.addMessage('system', `Model: ${oldModel} → ${newModel} (saved as default)${switchWarning}`);
       } else {
         // No arg or `list`: open the model picker (absorbs the old /models listing)
         ctx.addMessage('system', `Fetching models for ${ctx.actualProvider}...`);

--- a/src/ui/state/use-chat-controller.ts
+++ b/src/ui/state/use-chat-controller.ts
@@ -431,7 +431,8 @@ export function useChatController(): ChatController {
   // -- Modal handlers -------------------------------------------------------
   const handleModelSelect = useCallback((selectedModel: string) => {
     setModel(selectedModel);
-    addMessage('system', `Model: ${selectedModel}`);
+    config.set('defaultModel', selectedModel);
+    addMessage('system', `Model: ${selectedModel} (saved as default)`);
     modal.setModalMode('none');
     modal.setAvailableModels([]);
   }, [addMessage, setModel, modal]);
@@ -491,7 +492,9 @@ export function useChatController(): ChatController {
   const handleProviderSelect = useCallback((entry: ProviderEntry) => {
     if (entry.configured) {
       setProvider(entry.id);
-      addMessage('system', `Provider: ${entry.label}${entry.id === 'ollama' ? ' (local)' : ''}`);
+      config.set('defaultProvider', entry.id);
+      config.unset('defaultModel');
+      addMessage('system', `Provider: ${entry.label}${entry.id === 'ollama' ? ' (local)' : ''} (saved as default)`);
       modal.setModalMode('none');
       modal.setProviderEntries([]);
       return;
@@ -526,7 +529,9 @@ export function useChatController(): ChatController {
         config.setProviderCred(entry.id, { apiKey: value });
       }
       setProvider(entry.id);
-      addMessage('system', `✓ Configured ${entry.label}. Provider switched.`);
+      config.set('defaultProvider', entry.id);
+      config.unset('defaultModel');
+      addMessage('system', `✓ Configured ${entry.label}. Provider switched and saved as default.`);
     } catch (e) {
       addMessage('error', `Failed to configure ${entry.label}: ${e instanceof Error ? e.message : String(e)}`);
     }

--- a/tests/commands-model-loading.test.ts
+++ b/tests/commands-model-loading.test.ts
@@ -29,6 +29,7 @@ vi.mock('../src/config.js', () => ({
   default: {},
   get: vi.fn(),
   set: vi.fn(),
+  unset: vi.fn(),
   getApiKey: vi.fn(),
   getBaseUrl: vi.fn(),
   getConfiguredProviders: vi.fn(() => []),
@@ -369,5 +370,32 @@ describe('/config set — nested routing keys', () => {
 
     expect(config.set).not.toHaveBeenCalled();
     expect(getMessages(ctx).at(-1)?.content).toMatch(/between 0 and 1/);
+  });
+});
+
+describe('model/provider persistence (#233)', () => {
+  it('persists defaultModel on explicit /model switch', async () => {
+    const config = await import('../src/config.js');
+    const ctx = makeCtx();
+    await handleCommand('/model gpt-5.3-codex', ctx);
+    expect(vi.mocked(config.set)).toHaveBeenCalledWith('defaultModel', 'gpt-5.3-codex');
+  });
+
+  it('persists defaultProvider and clears defaultModel on /provider switch', async () => {
+    const config = await import('../src/config.js');
+    const providers = await import('../src/providers/index.js');
+    vi.mocked(providers.getAvailableProviders).mockReturnValue(['google'] as never);
+    const ctx = makeCtx();
+    await handleCommand('/provider google', ctx);
+    expect(vi.mocked(config.set)).toHaveBeenCalledWith('defaultProvider', 'google');
+    expect(vi.mocked(config.unset)).toHaveBeenCalledWith('defaultModel');
+  });
+
+  it('persists nothing on /model list', async () => {
+    const config = await import('../src/config.js');
+    vi.mocked(config.set).mockClear();
+    const ctx = makeCtx();
+    await handleCommand('/model list', ctx);
+    expect(vi.mocked(config.set)).not.toHaveBeenCalledWith('defaultModel', expect.anything());
   });
 });


### PR DESCRIPTION
## Summary
Live-test catch: /model gpt-5.3-codex in one session, next session silently starts on gpt-4o — selections were session-only.
- /model <name> persists defaultModel; /provider <name> persists defaultProvider and clears defaultModel (stale cross-provider models must not leak); both picker paths and the api-key setup path persist too; switch messages say '(saved as default)'
- New config.unset(key) — conf throws on set(undefined)
- /model list and rejected switches persist nothing

## Test Plan
- 3 new tests in commands-model-loading (persist on switch, persist+clear on provider, nothing on list)
- npm test: full suite green

Fixes #233