### PR TITLE
Release 3.0.0

### DIFF
--- a/CALLIOPE.md
+++ b/CALLIOPE.md
@@ -8,7 +8,7 @@ execution, git-based checkpoints, project memory, MCP, and a flag-gated
 fleet-coordination mode. Positioning: **the private-AI agent CLI** — the
 best harness for models you run yourself.
 
-**Current Version:** 3.0.0-alpha.1
+**Current Version:** 3.0.0
 **Organization:** Calliope Labs Inc
 **Repository:** https://github.com/calliopeai/calliope-cli
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,37 @@
 # Changelog
 
-## 3.0.0-alpha.1 — 2026-07-04
+## 3.0.0 — 2026-07-09
 
 v3 is a deliberate reduction. The goal: a fast, predictable, maintainable
 agent CLI with a small core and no lock-in — the best harness for models you
 run yourself. Roughly 70% of the v2 surface was removed; everything that
 stayed is tested (93%+ line coverage, 90% floor enforced).
+
+### Added
+
+- **Single-binary distribution** — cross-compiled binaries for macOS
+  (arm64/x64) and Linux (x64/arm64), built on every release with checksums;
+  `packaging/install.sh` and a Homebrew formula. Cold start: 75ms median.
+- **Performance budgets in CI** — every PR gates on cold start, keystroke
+  latency (p95 2.5ms measured vs 16ms budget), and long-session memory
+  flatness (`npm run bench`).
+- **Local-model excellence** — schema simplification, a one-round
+  repair loop with grammar-constrained retries, hash-anchored edits,
+  a compact prompt profile, and capability probing for Ollama and
+  OpenAI-compatible servers. Verified live against gemma4:31b.
+- **Governance** — tamper-evident audit run logs (hash-chained JSONL, on by
+  default, secrets redacted), `calliope replay` with chain verification
+  (exit 4 on tampering), `calliope cost` spend/tool reporting, per-run and
+  per-project budget caps (headless exit 3), and a fail-closed pre-tool
+  policy hook for external engines.
+- **ACP agent mode** — `calliope acp` speaks the Agent Client Protocol over
+  stdio for Zed/JetBrains/Neovim, with editor-buffer file access.
+- **Evidence-based agent behavior** — plan mode requires reading before
+  proposing (unverified plans are marked in the transcript), and the
+  plan-to-work transition binds terse approvals to execution.
+- **Config that survives** — `/model` and `/provider` selections persist;
+  credentials migrate automatically from v2; a global
+  `~/.config/calliope/cli.env` joins the env-file load order.
 
 ### Removed
 
@@ -58,13 +84,11 @@ stayed is tested (93%+ line coverage, 90% floor enforced).
   command, unreferenced config keys, an 8-way layout switch whose branches
   rendered identically.
 
-### Coming in 3.0.0 stable
+### Notes
 
-Single-binary distribution (brew/curl, no Node required), enforced
-performance budgets (cold start, keystroke latency, flat long-session
-memory), and UI rendering rework. After that: local-model edit-reliability
-hardening and governance primitives (replayable run logs, budget caps,
-audit trail).
+The removals were shipped and validated across a three-day live-testing
+cycle that itself produced six of the fixes above — including two cases
+where the audit log caught an agent claiming work it had not done.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Project
 
-Multi-model AI agent CLI (`@calliopelabs/cli` v3.0.0-alpha.1). TypeScript + React/Ink, ESM modules. Node ≥ 20.
+Multi-model AI agent CLI (`@calliopelabs/cli` v3.0.0). TypeScript + React/Ink, ESM modules. Node ≥ 20.
 
 ## Development Rules
 

--- a/bootstrap.md
+++ b/bootstrap.md
@@ -6,7 +6,7 @@
 > wins**. Keep it updated as the codebase evolves.
 
 `@calliopelabs/cli` (`calliope`) — a multi-model AI agent CLI. TypeScript +
-React/Ink, ESM. v3.0.0-alpha.1. Node ≥ 20.
+React/Ink, ESM. v3.0.0. Node ≥ 20.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calliopelabs/cli",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0",
   "description": "The private-AI agent CLI - one terminal agent for any model backend, including the ones you run yourself",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- package.json 3.0.0-alpha.1 → 3.0.0
- CHANGELOG: consolidated 3.0.0 entry — full Added section joins the removal ledger; notes record the live-testing cycle
- README/CALLIOPE.md/bootstrap.md/CLAUDE.md version references updated; 'coming in stable' phrasing replaced with shipped reality

## Test Plan
- npm test: 3,771 passed, 4 skipped; build clean

After merge: GitHub release v3.0.0 publishes the notes and fires npm publish + the 4-target binary build.