### PR TITLE
Release 3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,14 @@ updates:
       interval: "weekly"
       day: "monday"
     groups:
+      # Minor and patch updates ride together in one PR. Majors are excluded so
+      # each arrives on its own and can be reviewed against a real changelog:
+      # #240 swept six majors (openai 4->6, typescript 5->7, ink 6->7,
+      # inquirer 7->8, conf 13->15, @types/node 22->26) into a single PR.
       all-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 5

--- a/CALLIOPE.md
+++ b/CALLIOPE.md
@@ -8,7 +8,7 @@ execution, git-based checkpoints, project memory, MCP, and a flag-gated
 fleet-coordination mode. Positioning: **the private-AI agent CLI** — the
 best harness for models you run yourself.
 
-**Current Version:** 3.0.0
+**Current Version:** 3.1.0
 **Organization:** Calliope Labs Inc
 **Repository:** https://github.com/calliopeai/calliope-cli
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 3.1.0 — 2026-07-20
+
+Restores a green build after the grouped dependency sweep in #240, which
+landed six major bumps at once (openai 4 to 6, typescript 5 to 7, ink 6 to 7,
+inquirer 7 to 8, conf 13 to 15, @types/node 22 to 26) and broke compilation
+on `main`.
+
+### Added
+
+- **Fireworks AI in the setup wizard** — Fireworks was already a supported
+  provider throughout the config, router, model detection, and compat layers,
+  but it was missing from the setup menu and from environment detection, so
+  `FIREWORKS_API_KEY` could not be selected during setup. Both are now wired.
+
+### Fixed
+
+- **OpenAI SDK 6 tool-call parsing** — `ChatCompletionMessageToolCall` became
+  a union of function and custom tool calls, so `parseOpenAIToolCalls` no
+  longer compiled. Tool calls are now narrowed on the `type` discriminator;
+  custom tool calls, which the CLI never sends, are skipped.
+- **Provider typing in the setup wizard** — the detected-provider list was
+  typed as `string[]` where the prompt expects `LLMProvider`, masking the
+  missing Fireworks entry above.
+- **Dependabot no longer groups major updates** — majors now arrive as
+  individual pull requests so each can be reviewed against its own changelog,
+  rather than riding in with the weekly minor and patch sweep.
+
 ## 3.0.0 — 2026-07-09
 
 v3 is a deliberate reduction. The goal: a fast, predictable, maintainable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Project
 
-Multi-model AI agent CLI (`@calliopelabs/cli` v3.0.0). TypeScript + React/Ink, ESM modules. Node ≥ 20.
+Multi-model AI agent CLI (`@calliopelabs/cli` v3.1.0). TypeScript + React/Ink, ESM modules. Node ≥ 20.
 
 ## Development Rules
 

--- a/bootstrap.md
+++ b/bootstrap.md
@@ -6,7 +6,7 @@
 > wins**. Keep it updated as the codebase evolves.
 
 `@calliopelabs/cli` (`calliope`) — a multi-model AI agent CLI. TypeScript +
-React/Ink, ESM. v3.0.0. Node ≥ 20.
+React/Ink, ESM. v3.1.0. Node ≥ 20.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calliopelabs/cli",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The private-AI agent CLI - one terminal agent for any model backend, including the ones you run yourself",
   "keywords": [
     "ai",

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -104,6 +104,10 @@ export function parseOpenAIToolCalls(toolCalls: OpenAI.Chat.Completions.ChatComp
 
   const result: ToolCall[] = [];
   for (const tc of toolCalls) {
+    // The SDK models tool calls as a union; we only ever send function tools,
+    // so anything else (custom tools) is not ours to parse.
+    if (tc.type !== 'function') continue;
+
     let parsedArgs: Record<string, unknown> = {};
     try {
       parsedArgs = JSON.parse(tc.function.arguments);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -36,13 +36,14 @@ export async function runSetup(force = false): Promise<boolean> {
   console.log();
 
   // Check for existing environment variables
-  const envProviders: string[] = [];
+  const envProviders: LLMProvider[] = [];
   if (process.env.ANTHROPIC_API_KEY) envProviders.push('anthropic');
   if (process.env.GOOGLE_API_KEY) envProviders.push('google');
   if (process.env.OPENAI_API_KEY) envProviders.push('openai');
   if (process.env.TOGETHER_API_KEY) envProviders.push('together');
   if (process.env.OPENROUTER_API_KEY) envProviders.push('openrouter');
   if (process.env.GROQ_API_KEY) envProviders.push('groq');
+  if (process.env.FIREWORKS_API_KEY) envProviders.push('fireworks');
   if (process.env.MISTRAL_API_KEY) envProviders.push('mistral');
   if (process.env.OLLAMA_BASE_URL) envProviders.push('ollama');
   if (process.env.AI21_API_KEY) envProviders.push('ai21');
@@ -66,6 +67,7 @@ export async function runSetup(force = false): Promise<boolean> {
       { value: 'openrouter', name: 'OpenRouter', description: 'Access multiple models via one API' },
       { value: 'together', name: 'Together AI', description: 'Open source models (Llama, Mixtral)' },
       { value: 'groq', name: 'Groq', description: 'Ultra-fast inference' },
+      { value: 'fireworks', name: 'Fireworks AI', description: 'Fast open source model inference' },
       { value: 'mistral', name: 'Mistral AI', description: 'Mistral Large - European AI' },
       { value: 'ollama', name: 'Ollama (Local)', description: 'Run models locally - no API key needed' },
       { value: 'litellm', name: 'LiteLLM Proxy', description: 'Unified proxy for multiple providers' },

--- a/tests/openai.test.ts
+++ b/tests/openai.test.ts
@@ -1273,6 +1273,25 @@ describe('parseOpenAIToolCalls (additional branch coverage)', () => {
       expect(e.message).toContain('Raw: {{{{');
     }
   });
+
+  it('skips custom tool calls and parses only function tool calls', () => {
+    const toolCalls = [
+      {
+        id: 'call_custom',
+        type: 'custom' as const,
+        custom: { name: 'not_ours', input: 'raw text' },
+      },
+      {
+        id: 'call_fn',
+        type: 'function' as const,
+        function: { name: 'read_file', arguments: '{"path":"/a.txt"}' },
+      },
+    ];
+    const result = parseOpenAIToolCalls(toolCalls);
+    expect(result).toEqual([
+      { id: 'call_fn', name: 'read_file', arguments: { path: '/a.txt' } },
+    ]);
+  });
 });
 
 describe('chatOpenAI (Responses API streaming, additional coverage)', () => {


### PR DESCRIPTION
Restores a green build. `main` has been red since 2026-07-18.

## What happened

Dependabot PR #240 grouped **six major bumps** into a single PR: openai 4 to 6, typescript 5 to 7, ink 6 to 7, inquirer 7 to 8, conf 13 to 15, @types/node 22 to 26. CI correctly failed on that PR (`build` = FAILURE) and it was merged anyway, breaking both `CI` and `Build and Push` on `main` with the same two type errors.

## Fixes

**OpenAI SDK 6 tool-call union.** `ChatCompletionMessageToolCall` is now `Function | Custom`, so `tc.function` no longer type-checks. Narrowed on the `type` discriminator; custom tool calls, which the CLI never sends, are skipped.

**Provider typing in the setup wizard.** `envProviders` was `string[]` where the prompt expects `LLMProvider`. Fixing the type surfaced a real latent bug: **Fireworks was missing from the setup wizard entirely**, no menu entry and no env detection, despite being fully supported in `config.ts`, `router.ts`, `model-detection.ts`, `compat.ts`, and the error hints. Anyone with `FIREWORKS_API_KEY` could not select it through setup. Both are now wired; it falls to the generic API-key branch, which is correct.

**Dependabot no longer groups majors.** The weekly group is now scoped to `minor` and `patch`, so each major arrives as its own reviewable PR.

## Verification

- `npm run build` and `npx tsc --noEmit` clean
- 3772 tests pass across 113 files, including a new regression test for the custom-tool-call skip
- `npm run bench` PASS on all four budgets (cold start 102ms, keystroke p95 8.1ms, memory slope 17.35KB/msg, growth 12.68MB)
- The other five majors verified at runtime, not just compiled: conf 15 reads config written by conf 13 (no user-config orphaning), inquirer 8 exports intact, ink 7 renders the TUI correctly, and a live headless provider call round-trips

## Note

`main` has no branch protection, which is why a red check could be merged. Adding a required status check separately.